### PR TITLE
Renewed Home Screen Implementation (Integrated UI Implementation)

### DIFF
--- a/app/src/main/java/com/doyoonkim/knutice/navigation/MainServiceNavGraph.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/navigation/MainServiceNavGraph.kt
@@ -32,7 +32,7 @@ import com.doyoonkim.knutice.di.components.DaggerNoticeSearchSceneComponent
 import com.doyoonkim.knutice.di.components.DaggerNotificationPreferencesSceneComponent
 import com.doyoonkim.knutice.di.components.DaggerSettingsSceneComponent
 import com.doyoonkim.knutice.di.util.DefaultSystemService
-import com.doyoonkim.main.home.HomeScreen
+import com.doyoonkim.main.home.HomeDashboard
 import com.doyoonkim.main.notice.NoticeByMajorScreen
 import com.doyoonkim.main.notice.NoticeDetailScreen
 import com.doyoonkim.main.notice.NoticeSearchScreen
@@ -69,7 +69,7 @@ fun NavGraphBuilder.mainServiceNavGraph(
             DaggerHomeSceneComponent.factory().create(DefaultSystemService(appComponent))
         }
 
-        HomeScreen(
+        HomeDashboard(
             modifier = Modifier.padding(horizontal = 5.dp),
             viewModel = viewModel<HomeViewModel>(factory = sceneComponent.viewModelFactory()),
             bottomPadding = contentPadding.calculateBottomPadding(),
@@ -79,13 +79,14 @@ fun NavGraphBuilder.mainServiceNavGraph(
             },
             onMoreNoticeRequested = { dest ->
                 navController.run {
-                    when(dest) {
+                    when (dest) {
                         Destination.MORE_GENERAL -> navigate(NavRoutes.GeneralNotices.route)
                         Destination.MORE_ACADEMIC -> navigate(NavRoutes.AcademicNotices.route)
                         Destination.MORE_SCHOLARSHIP -> navigate(NavRoutes.ScholarshipNotices.route)
                         Destination.MORE_EVENT -> navigate(NavRoutes.EventNotices.route)
                         Destination.MORE_EMPLOYMENT -> navigate(NavRoutes.EmploymentNotices.route)
-                        else -> { /* DO NOTHING. */ }
+                        else -> { /* DO NOTHING. */
+                        }
                     }
                 }
             },
@@ -99,7 +100,10 @@ fun NavGraphBuilder.mainServiceNavGraph(
                     putString(FirebaseAnalytics.Param.DESTINATION, url)
                 })
                 navController.navigate("tipDetail/${category.name}/${Uri.encode(url)}")
-            }
+            },
+            onMoreMajorNoticeRequested = {
+                navController.navigate(NavRoutes.MajorNotices.route)
+            },
         )
     }
 

--- a/feature/main/src/main/java/com/doyoonkim/main/contract/HomeContract.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/contract/HomeContract.kt
@@ -6,6 +6,7 @@ import com.doyoonkim.common.base.UiSideEffect
 import com.doyoonkim.common.base.UiState
 import com.doyoonkim.common.navigation.Destination
 import com.doyoonkim.common.ui.TipCategory
+import com.doyoonkim.model.MajorCategory
 import com.doyoonkim.model.NoticeCategory
 import com.doyoonkim.model.NoticeVO
 import com.doyoonkim.model.TipVO
@@ -13,7 +14,8 @@ import com.doyoonkim.model.TopThreeNoticeVO
 
 data class HomeViewState(
     val mainContentState: MainContentState = MainContentState(),
-    val tipState: TipState = TipState()
+    val tipState: TipState = TipState(),
+    val majorNoticesState: MajorNoticesState = MajorNoticesState()
 ) : UiState
 
 // Child State: Main Content (TopThreeNotices)
@@ -34,10 +36,19 @@ data class TipState(
     val tips: List<TipVO> = emptyList()
 )
 
+// Child State: Subscribed Major/College Notice
+data class MajorNoticesState(
+    val isLoading: Boolean = true,
+    val isError: Boolean = false,
+    val subscribed: MajorCategory = MajorCategory.UNSPECIFIED,
+    val majorNotices: List<NoticeVO> = listOf(NoticeVO(), NoticeVO(), NoticeVO())
+)
+
 sealed interface HomeEvent : UiEvent {
     data object RequestMainContents: HomeEvent
     data class RequestNoticeDetail(val id: Int, val url: String): HomeEvent
     data class RequestMore(val category: NoticeCategory): HomeEvent
+    data object RequestMoreMajorNotices: HomeEvent
     data object RequestSettings: HomeEvent
     data class RequestTipDetail(val category: TipCategory, val url: String): HomeEvent
     data object GoBack: HomeEvent
@@ -46,6 +57,7 @@ sealed interface HomeEvent : UiEvent {
 sealed class HomeSideEffect : UiSideEffect {
     data class NavToNoticeDetail(val id: Int, val url: String): HomeSideEffect()
     data class NavToMoreNoticeInCategory(val dest: Destination): HomeSideEffect()
+    data object NavToMoreMajorNotices: HomeSideEffect()
     data class NavToTipDetail(val category: TipCategory, val url: String): HomeSideEffect()
     data object NavToSettings: HomeSideEffect()
     data object NavToBack: HomeSideEffect()
@@ -64,5 +76,12 @@ sealed interface HomeMutation: UiMutation {
         data object Loading: Tip
         data class Success(val tips: List<TipVO>): Tip
         data class Failure(val reason: String): Tip
+    }
+
+    // Major Notices Processing
+    sealed interface MajorNotices: HomeMutation {
+        data object Loading: MajorNotices
+        data class Success(val category: MajorCategory, val notices: List<NoticeVO>): MajorNotices
+        data class Failure(val reason: String): MajorNotices
     }
 }

--- a/feature/main/src/main/java/com/doyoonkim/main/home/HomeDashboard.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/home/HomeDashboard.kt
@@ -1,0 +1,269 @@
+package com.doyoonkim.main.home
+
+import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.Image
+import androidx.compose.foundation.background
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.material3.IconButton
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.Scaffold
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.LaunchedEffect
+import androidx.compose.runtime.collectAsState
+import androidx.compose.runtime.getValue
+import androidx.compose.ui.Alignment
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.graphics.Color
+import androidx.compose.ui.graphics.ColorFilter
+import androidx.compose.ui.res.painterResource
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import com.doyoonkim.common.MajorResources
+import com.doyoonkim.common.NoticeResources
+import com.doyoonkim.common.R
+import com.doyoonkim.common.navigation.Destination
+import com.doyoonkim.common.theme.displayBackground
+import com.doyoonkim.common.theme.secondaryBackground
+import com.doyoonkim.common.theme.title
+import com.doyoonkim.common.ui.EntryPointButton
+import com.doyoonkim.common.ui.HorizontalContentPager
+import com.doyoonkim.common.ui.PlaceholderScreen
+import com.doyoonkim.common.ui.TipCategory
+import com.doyoonkim.common.ui.TipPager
+import com.doyoonkim.common.ui.TopAppBarWithActions
+import com.doyoonkim.main.contract.HomeEvent
+import com.doyoonkim.main.contract.HomeSideEffect
+import com.doyoonkim.main.ui.NotificationPreviewList
+import com.doyoonkim.main.viewmodel.HomeViewModel
+import com.doyoonkim.model.NoticeCategory
+
+@Composable
+fun HomeDashboard(
+    modifier: Modifier = Modifier,
+    viewModel: HomeViewModel,
+    bottomPadding: Dp = 0.dp,
+    onSettingsRequested: () -> Unit,
+    onGoBackAction: () -> Unit,
+    onMoreNoticeRequested: (Destination) -> Unit,
+    onMoreMajorNoticeRequested: () -> Unit,
+    onFullContentRequested: (Int, String) -> Unit,
+    onTipClicked: (TipCategory, String) -> Unit
+) {
+    // UiState
+    val uiState by viewModel.uiState.collectAsState()
+
+    // Back Button/Gesture actions
+    BackHandler {
+        viewModel.sendUiEvent(HomeEvent.GoBack)
+    }
+
+    // SideEffect Handling
+    LaunchedEffect(Unit) {
+        viewModel.sendUiEvent(HomeEvent.RequestMainContents)
+
+        // SideEffect Channel Subscription
+        viewModel.uiSideEffect.collect { effect ->
+            when (effect) {
+                is HomeSideEffect.NavToNoticeDetail -> {
+                    with (effect) {
+                        onFullContentRequested(id, url)
+                    }
+                }
+                is HomeSideEffect.NavToMoreNoticeInCategory -> {
+                    with (effect) {
+                        onMoreNoticeRequested(dest)
+                    }
+                }
+                is HomeSideEffect.NavToMoreMajorNotices -> {
+                    onMoreMajorNoticeRequested()
+                }
+                is HomeSideEffect.NavToTipDetail -> {
+                    with (effect) {
+                        onTipClicked(category, url)
+                    }
+                }
+                is HomeSideEffect.NavToSettings -> {
+                    onSettingsRequested()
+                }
+                is HomeSideEffect.NavToBack -> {
+                    onGoBackAction()
+                }
+            }
+        }
+    }
+
+    // Top Level Scaffold
+    Scaffold(
+        modifier = Modifier.fillMaxSize(),
+        topBar = {
+            TopAppBarWithActions(
+                titleText = stringResource(R.string.app_name)
+            ) {
+                IconButton(
+                    onClick = { viewModel.sendUiEvent(HomeEvent.RequestSettings) }
+                ) {
+                    Image(
+                        painter = painterResource(R.drawable.baseline_settings_24),
+                        contentDescription = "Settings",
+                        modifier = Modifier.wrapContentSize(),
+                        colorFilter = ColorFilter.tint(MaterialTheme.colorScheme.title)
+                    )
+                }
+            }
+        },
+        containerColor = MaterialTheme.colorScheme.displayBackground
+    ) { innerPadding ->
+        if (uiState.mainContentState.isError) {
+            PlaceholderScreen(
+                modifier = modifier.fillMaxSize()
+                    .padding(innerPadding)
+                    .padding(bottom = bottomPadding),
+                imageResource = R.drawable.wifi,
+                contentText = stringResource(R.string.error_no_network_connection)
+            )
+        } else {
+            LazyColumn(
+                modifier = modifier.padding(innerPadding)
+                    .background(MaterialTheme.colorScheme.displayBackground),
+                horizontalAlignment = Alignment.CenterHorizontally,
+                verticalArrangement = Arrangement.Top
+            ) {
+                if (!uiState.tipState.isError && uiState.tipState.tips.isNotEmpty()) {
+                    item("tip") {
+                        TipPager(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .height(50.dp)
+                                .padding(5.dp),
+                            tips = uiState.tipState.tips
+                        ) {
+                            viewModel.sendUiEvent(HomeEvent.RequestTipDetail(TipCategory.UPDATES, it))
+                        }
+                        Spacer(Modifier.height(15.dp))
+                    }
+                }
+
+                item("Service Entry points") {
+                    Row(
+                        modifier = Modifier.fillMaxWidth()
+                            .wrapContentHeight()
+                            .padding(horizontal = 7.dp)
+                            .background(Color.Transparent),
+                        verticalAlignment = Alignment.CenterVertically,
+                        horizontalArrangement = Arrangement.spacedBy(10.dp)
+                    ) {
+                        EntryPointButton(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .weight(1f),
+                            text = "학식 조회",
+                            painter = painterResource(R.drawable.icon_dining_menu),
+                            containerColor = MaterialTheme.colorScheme.secondaryBackground,
+                            textColor = MaterialTheme.colorScheme.title,
+                            size = 140.dp
+                        )
+
+                        EntryPointButton(
+                            modifier = Modifier
+                                .fillMaxWidth()
+                                .weight(1f),
+                            text = "열람실 현황",
+                            painter = painterResource(R.drawable.icon_study_area),
+                            containerColor = MaterialTheme.colorScheme.secondaryBackground,
+                            textColor = MaterialTheme.colorScheme.title,
+                            size = 140.dp
+                        )
+                    }
+                }
+
+                item("main notice area") {
+                    HorizontalContentPager(
+                        modifier = Modifier.fillMaxWidth(),
+                        progressDelay = 7000L,
+                        startingPage = 0,
+                        size = 5
+                    ) { index ->
+                        val targetKey = index % 5
+                        val category = NoticeCategory.entries[targetKey]
+                        val notices = when (category) {
+                            NoticeCategory.GENERAL_NEWS -> {
+                                uiState.mainContentState.notificationGeneral
+                            }
+                            NoticeCategory.ACADEMIC_NEWS -> {
+                                uiState.mainContentState.notificationAcademic
+                            }
+                            NoticeCategory.SCHOLARSHIP_NEWS -> {
+                                uiState.mainContentState.notificationScholarship
+                            }
+                            NoticeCategory.EVENT_NEWS -> {
+                                uiState.mainContentState.notificationEvent
+                            }
+                            NoticeCategory.EMPLOYMENT_NEWS -> {
+                                uiState.mainContentState.notificationEmployment
+                            }
+                            NoticeCategory.Unspecified -> {
+                                emptyList()
+                            }
+                        }
+
+                        NotificationPreviewList(
+                            listTitle = stringResource(
+                                NoticeResources.getStringResourcesByCategory(category.toString())
+                            ),
+                            titleColor = NoticeResources.getColorResourceByCategory(category.toString()),
+                            isContentLoading = uiState.mainContentState.isLoading,
+                            contents = notices,
+                            onMoreClicked = {
+                                viewModel.sendUiEvent(HomeEvent.RequestMore(category))
+                            }
+                        ) {
+                            viewModel.sendUiEvent(HomeEvent.RequestNoticeDetail(it.nttId, it.url))
+                        }
+
+                    }
+                }
+
+                item("notice by selected major") {
+                    if (uiState.majorNoticesState.isError) {
+                        PlaceholderScreen(
+                            modifier = modifier
+                                .fillMaxWidth(),
+                            imageResource = R.drawable.question_mark,
+                            contentText = stringResource(R.string.title_major_select)
+                        )
+                    } else {
+                        NotificationPreviewList(
+                            listTitle = stringResource(
+                                MajorResources.getLocalizedString(
+                                    uiState.majorNoticesState.subscribed.name
+                                )
+                            ),
+                            titleColor = MaterialTheme.colorScheme.title,
+                            isContentLoading = uiState.majorNoticesState.isLoading,
+                            contents = uiState.majorNoticesState.majorNotices,
+                            onMoreClicked = {
+                                viewModel.sendUiEvent(HomeEvent.RequestMoreMajorNotices)
+                            }
+                        ) {
+                            viewModel.sendUiEvent(HomeEvent.RequestNoticeDetail(it.nttId, it.url))
+                        }
+                    }
+                }
+
+                item {
+                    Spacer(Modifier.height(bottomPadding))
+                }
+            }
+        }
+    }
+}

--- a/feature/main/src/main/java/com/doyoonkim/main/home/HomeScreen.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/home/HomeScreen.kt
@@ -3,60 +3,45 @@ package com.doyoonkim.main.home
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.layout.Arrangement
-import androidx.compose.foundation.layout.Column
-import androidx.compose.foundation.layout.PaddingValues
-import androidx.compose.foundation.layout.Row
 import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
 import androidx.compose.foundation.layout.padding
-import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
-import androidx.compose.foundation.rememberScrollState
-import androidx.compose.foundation.verticalScroll
 import androidx.compose.material3.IconButton
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
-import androidx.compose.material3.Text
-import androidx.compose.material3.TextButton
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.collectAsState
 import androidx.compose.runtime.getValue
 import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
-import androidx.compose.ui.graphics.Color
 import androidx.compose.ui.graphics.ColorFilter
 import androidx.compose.ui.res.painterResource
 import androidx.compose.ui.res.stringResource
-import androidx.compose.ui.text.font.FontWeight
 import androidx.compose.ui.unit.Dp
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.unit.sp
 import com.doyoonkim.common.theme.notificationType1
 import com.doyoonkim.common.theme.notificationType2
 import com.doyoonkim.common.theme.notificationType3
 import com.doyoonkim.common.theme.notificationType4
-import com.doyoonkim.common.theme.subTitle
 import com.doyoonkim.common.R
 import com.doyoonkim.common.navigation.Destination
 import com.doyoonkim.common.theme.displayBackground
 import com.doyoonkim.common.theme.notificationType5
-import com.doyoonkim.common.theme.onAnyBackground
 import com.doyoonkim.common.theme.title
-import com.doyoonkim.common.ui.NotificationPreviewCard
 import com.doyoonkim.common.ui.PlaceholderScreen
 import com.doyoonkim.common.ui.TipCategory
-import com.doyoonkim.common.ui.TipContainer
 import com.doyoonkim.common.ui.TipPager
 import com.doyoonkim.common.ui.TopAppBarWithActions
 import com.doyoonkim.main.contract.HomeEvent
 import com.doyoonkim.main.contract.HomeSideEffect
+import com.doyoonkim.main.ui.NotificationPreviewList
 import com.doyoonkim.main.viewmodel.HomeViewModel
 import com.doyoonkim.model.NoticeCategory
-import com.doyoonkim.model.NoticeVO
 
 @Composable
 fun HomeScreen(
@@ -103,6 +88,7 @@ fun HomeScreen(
                 is HomeSideEffect.NavToBack -> {
                     onGoBackAction()
                 }
+                else -> { /* Currently Do Nothing */ }
             }
         }
     }
@@ -241,67 +227,6 @@ fun HomeScreen(
                 item {
                     Spacer(Modifier.height(bottomPadding))
                 }
-            }
-        }
-    }
-}
-
-@Composable
-fun NotificationPreviewList(
-    modifier: Modifier = Modifier,
-    listTitle: String = "List Title goes here",
-    titleColor: Color = Color.Unspecified,
-    isContentLoading: Boolean = false,
-    contents: List<NoticeVO> = listOf(),
-    onMoreClicked: () -> Unit = {  },
-    onNoticeClicked: (NoticeVO) -> Unit
-) {
-    Column(
-        modifier = Modifier
-            .fillMaxWidth()
-            .padding(7.dp),
-        verticalArrangement = Arrangement.spacedBy(12.dp),
-        horizontalAlignment = Alignment.CenterHorizontally
-    ) {
-        Row(
-            Modifier
-                .fillMaxWidth()
-                .wrapContentHeight(),
-            verticalAlignment = Alignment.CenterVertically,
-            horizontalArrangement = Arrangement.Center
-        ) {
-            Text(
-                modifier = Modifier
-                    .wrapContentHeight()
-                    .weight(6f),
-                text = listTitle,
-                color = titleColor,
-                fontSize = 18.sp,
-                fontWeight = FontWeight.ExtraBold
-            )
-
-            TextButton(
-                modifier = Modifier
-                    .fillMaxWidth()
-                    .weight(1f),
-                onClick = { onMoreClicked() },
-                contentPadding = PaddingValues(0.dp)
-            ) {
-                Text(
-                    modifier = Modifier.align(Alignment.CenterVertically),
-                    text = stringResource(R.string.btn_more),
-                    color = MaterialTheme.colorScheme.subTitle,
-                    fontWeight = FontWeight.Medium
-                )
-            }
-        }
-        contents.forEach { content ->
-            NotificationPreviewCard(
-                notificationTitle = content.title,
-                notificationInfo = "[${content.departName}] ${content.timestamp}",
-                isLoading = isContentLoading
-            ) {
-                onNoticeClicked(content)
             }
         }
     }

--- a/feature/main/src/main/java/com/doyoonkim/main/viewmodel/HomeViewModel.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/viewmodel/HomeViewModel.kt
@@ -3,7 +3,9 @@ package com.doyoonkim.main.viewmodel
 import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.doyoonkim.common.base.BaseViewModel
+import com.doyoonkim.common.di.AppPreferences
 import com.doyoonkim.common.navigation.Destination
+import com.doyoonkim.domain.usecases.FetchNoticesPerPage
 import com.doyoonkim.domain.usecases.FetchTips
 import com.doyoonkim.domain.usecases.FetchTopThreeNotices
 import com.doyoonkim.main.contract.HomeEvent
@@ -11,7 +13,9 @@ import com.doyoonkim.main.contract.HomeMutation
 import com.doyoonkim.main.contract.HomeSideEffect
 import com.doyoonkim.main.contract.HomeViewState
 import com.doyoonkim.main.contract.MainContentState
+import com.doyoonkim.main.contract.MajorNoticesState
 import com.doyoonkim.main.contract.TipState
+import com.doyoonkim.model.MajorCategory
 import com.doyoonkim.model.NoticeCategory
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
@@ -19,7 +23,8 @@ import javax.inject.Inject
 
 class HomeViewModel @Inject constructor(
     private val fetchTopThreeNotices: FetchTopThreeNotices,
-    private val fetchTips: FetchTips
+    private val fetchTips: FetchTips,
+    private val appPreferences: AppPreferences
 ) : BaseViewModel<HomeViewState, HomeEvent, HomeSideEffect, HomeMutation>() {
     override fun setInitialState(): HomeViewState = HomeViewState()
 
@@ -27,6 +32,8 @@ class HomeViewModel @Inject constructor(
         when (event) {
             is HomeEvent.RequestMainContents -> {
                 getTopThreeNotices()
+                // get Major Notices
+                getMajorSubscriptionStatus()
                 getTips()
             }
             is HomeEvent.RequestNoticeDetail -> {
@@ -52,6 +59,13 @@ class HomeViewModel @Inject constructor(
                     )
                 }
             }
+            is HomeEvent.RequestMoreMajorNotices -> {
+                with(uiState.value.majorNoticesState) {
+                    if (!isError && subscribed != MajorCategory.UNSPECIFIED) {
+                        sendSideEffect(HomeSideEffect.NavToMoreMajorNotices)
+                    }
+                }
+            }
             is HomeEvent.RequestSettings -> {
                 sendSideEffect(HomeSideEffect.NavToSettings)
             }
@@ -71,7 +85,11 @@ class HomeViewModel @Inject constructor(
         fetchTopThreeNotices()
             .fold(
                 onSuccess = { vo ->
-                    mutate(HomeMutation.MainContent.Success(vo))
+                    if (vo.isEmpty()) {
+                        mutate(HomeMutation.MainContent.Failure("Received Empty List"))
+                    } else {
+                        mutate(HomeMutation.MainContent.Success(vo))
+                    }
                 },
                 onFailure = {
                     mutate(HomeMutation.MainContent.Failure(it.stackTraceToString()))
@@ -94,6 +112,28 @@ class HomeViewModel @Inject constructor(
             }
     }
 
+    // Side Effect (Access SharedPreference)
+    private fun getMajorSubscriptionStatus() = viewModelScope.launch {
+        val subscribed = appPreferences.getSubscribedMajor()?.let {
+            MajorCategory.valueOf(it)
+        }
+        Log.d(this.javaClass.name, "Subscription: $subscribed")
+
+        subscribed?.let {
+            fetchTopThreeNotices.getMajorNotices(subscribed)
+                .fold(
+                    onSuccess = { result ->
+                        Log.d(this.javaClass.name, "Result: ${result.toString()}")
+                        mutate(HomeMutation.MajorNotices.Success(subscribed, result))
+                    },
+                    onFailure = { error ->
+                        Log.d(this.javaClass.name, "Result: ${error.stackTraceToString()}")
+                        mutate(HomeMutation.MajorNotices.Failure(error.stackTraceToString()))
+                    }
+                )
+        }
+    }
+
     // Main Reducer
     override fun reduce(currentState: HomeViewState, mutation: HomeMutation): HomeViewState {
         return when (mutation) {
@@ -102,6 +142,9 @@ class HomeViewModel @Inject constructor(
             )
             is HomeMutation.Tip -> currentState.copy(
                 tipState = mutation.reducer(currentState.tipState)
+            )
+            is HomeMutation.MajorNotices -> currentState.copy(
+                majorNoticesState = mutation.reducer(currentState.majorNoticesState)
             )
         }
     }
@@ -139,6 +182,22 @@ class HomeViewModel @Inject constructor(
                 tips = tips
             )
             is HomeMutation.Tip.Failure -> state.copy(
+                isLoading = false,
+                isError = true
+            )
+        }
+    }
+
+    private fun HomeMutation.MajorNotices.reducer(state: MajorNoticesState): MajorNoticesState {
+        return when (this) {
+            is HomeMutation.MajorNotices.Loading -> state.copy(isLoading = true)
+            is HomeMutation.MajorNotices.Success -> state.copy(
+                isLoading = false,
+                isError = false,
+                subscribed = category,
+                majorNotices = notices
+            )
+            is HomeMutation.MajorNotices.Failure -> state.copy(
                 isLoading = false,
                 isError = true
             )


### PR DESCRIPTION
* Change legacy Main Home Screen to Modern Dashboard style home screen to offer various entry points to upcoming services.

  - Implement new Dashboard Style HomeScreen with appropriate modification on corresponding ViewModel and Contract.
  - Implement FetchTopThreeNotices from subscribed Major notices enabled in DashboardHomeScreen.
    * Legacy HomeScreen is targeted to be removed after final confirmation is completed.
  - Replace Legacy HomeScreen with renewed HomeDashboard under MainNavigationGraph.