### PR TITLE
[FEAT] Widget Integration - Logic

### DIFF
--- a/app/src/main/java/com/doyoonkim/knutice/di/components/NotificationServiceComponent.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/di/components/NotificationServiceComponent.kt
@@ -6,6 +6,8 @@ import com.doyoonkim.data.di.NoticeRemoteModule
 import com.doyoonkim.data.di.TokenRemoteModule
 import com.doyoonkim.domain.di.TokenUseCaseModule
 import com.doyoonkim.knutice.di.modules.DispatcherModule
+import com.doyoonkim.knutice.di.modules.WorkSchedulerModule
+import com.doyoonkim.knutice.di.modules.WorkerModule
 import com.doyoonkim.knutice.di.util.SystemServices
 import com.doyoonkim.network.di.NotificationNetworkModule
 import com.doyoonkim.notification.di.NotificationModule
@@ -17,6 +19,7 @@ import dagger.Component
     modules = [
         NotificationModule::class,
         DispatcherModule::class,
+        WorkSchedulerModule::class,
         TokenUseCaseModule::class,
         TokenRemoteModule::class,
         NoticeRemoteModule::class,

--- a/app/src/main/java/com/doyoonkim/knutice/di/modules/WorkerModule.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/di/modules/WorkerModule.kt
@@ -6,7 +6,9 @@ import com.doyoonkim.domain.interfaces.AsyncFtsTaskScheduler
 import com.doyoonkim.knutice.task.AsyncFtsTableInsertion
 import com.doyoonkim.knutice.task.AsyncFtsTaskSchedulerImpl
 import com.doyoonkim.common.worker.IntermediateWorkerFactory
+import com.doyoonkim.domain.interfaces.AsyncNoticeWidgetTaskScheduler
 import com.doyoonkim.notification.task.PeriodicTokenRegistration
+import com.doyoonkim.widget.worker.AsyncNoticeWidgetTaskSchedulerImpl
 import dagger.Binds
 import dagger.Module
 import dagger.multibindings.IntoMap
@@ -33,7 +35,12 @@ abstract class WorkerModule {
 @Module
 abstract class WorkSchedulerModule {
     @Binds
-    abstract fun bindsWorkScheduler(
+    abstract fun bindsFtsWorkScheduler(
         impl: AsyncFtsTaskSchedulerImpl
     ): AsyncFtsTaskScheduler
+
+    @Binds
+    abstract fun bindNoticeWidgetWorkScheduler(
+        impl: AsyncNoticeWidgetTaskSchedulerImpl
+    ): AsyncNoticeWidgetTaskScheduler
 }

--- a/common/src/main/java/com/doyoonkim/common/di/AppPreferences.kt
+++ b/common/src/main/java/com/doyoonkim/common/di/AppPreferences.kt
@@ -3,6 +3,9 @@ package com.doyoonkim.common.di
 import android.content.SharedPreferences
 import javax.inject.Inject
 import androidx.core.content.edit
+import com.doyoonkim.model.WidgetCategoryPolicy
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
 
 class AppPreferences @Inject constructor(
     private val appPref: SharedPreferences
@@ -21,6 +24,12 @@ class AppPreferences @Inject constructor(
 
     // Widget Configuration (Category Selection)
     private val WIDGET_CATEGORY = "WIDGET_CATEGORY"
+
+    private val json = Json {
+        encodeDefaults = true
+        ignoreUnknownKeys = true
+        classDiscriminator = "type"
+    }
 
     /**
      * updateDeviceToken
@@ -48,12 +57,16 @@ class AppPreferences @Inject constructor(
     /**
      * Widget Configuration
      */
-    fun getWidgetCategory(): String? {
-        return appPref.getString(WIDGET_CATEGORY, null)
+    fun getWidgetCategoryPolicy(): WidgetCategoryPolicy {
+        val cachedPolicy = appPref.getString(WIDGET_CATEGORY, null)
+            ?: return WidgetCategoryPolicy.Unconfigured
+
+        return json.decodeFromString<WidgetCategoryPolicy>(cachedPolicy)
     }
 
-    fun updateWidgetCategory(newCategory: String) {
-        appPref.edit { putString(WIDGET_CATEGORY, newCategory) }
+    fun updateWidgetCategoryPolicy(policy: WidgetCategoryPolicy) {
+        val serializedString = json.encodeToString<WidgetCategoryPolicy>(policy)
+        appPref.edit { putString(WIDGET_CATEGORY, serializedString) }
     }
 
     fun isDatabaseSyncCompleted(): Boolean {

--- a/core/domain/src/main/java/com/doyoonkim/domain/interfaces/AsyncNoticeWidgetTaskScheduler.kt
+++ b/core/domain/src/main/java/com/doyoonkim/domain/interfaces/AsyncNoticeWidgetTaskScheduler.kt
@@ -1,0 +1,5 @@
+package com.doyoonkim.domain.interfaces
+
+interface AsyncNoticeWidgetTaskScheduler {
+    operator fun invoke()
+}

--- a/core/model/src/main/java/com/doyoonkim/model/NoticeWidgetCatetory.kt
+++ b/core/model/src/main/java/com/doyoonkim/model/NoticeWidgetCatetory.kt
@@ -1,0 +1,25 @@
+package com.doyoonkim.model
+
+import kotlinx.serialization.SerialName
+import kotlinx.serialization.Serializable
+
+
+// Widget Category Configuration (Handle both Fixed and Dynamic)
+@Serializable
+sealed interface WidgetCategoryPolicy {
+
+    // Not Yet Configured
+    @Serializable
+    @SerialName("unconfigured")
+    data object Unconfigured: WidgetCategoryPolicy
+
+    // Use provided category for State update. (Fixed)
+    @Serializable
+    @SerialName("main")
+    data class Main(val categoryKey: String) : WidgetCategoryPolicy
+
+    // Use Major Subscription status in SharedPreference for State Update (Dynamic)
+    @Serializable
+    @SerialName("major")
+    data object Major : WidgetCategoryPolicy
+}

--- a/core/notification/src/main/java/com/doyoonkim/notification/fcm/PushNotificationService.kt
+++ b/core/notification/src/main/java/com/doyoonkim/notification/fcm/PushNotificationService.kt
@@ -1,25 +1,21 @@
 package com.doyoonkim.notification.fcm
 
 import android.Manifest
-import android.content.Intent
 import android.util.Log
 import androidx.annotation.RequiresPermission
 import com.doyoonkim.common.di.AppInjectorProvider
 import com.doyoonkim.common.di.TokenHandler
-import com.google.firebase.messaging.Constants.MessageNotificationKeys
+import com.doyoonkim.domain.interfaces.AsyncNoticeWidgetTaskScheduler
 import com.google.firebase.messaging.FirebaseMessagingService
 import com.google.firebase.messaging.RemoteMessage
 import dagger.Lazy
-import kotlinx.coroutines.CoroutineScope
-import kotlinx.coroutines.Dispatchers
-import kotlinx.coroutines.SupervisorJob
-import kotlinx.coroutines.cancelAndJoin
-import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class PushNotificationService : FirebaseMessagingService() {
     @Inject lateinit var handlerProvider: Lazy<PushNotificationHandler>
     @Inject lateinit var tokenHandler: Lazy<TokenHandler>
+
+    @Inject lateinit var widgetSyncTaskScheduler: Lazy<AsyncNoticeWidgetTaskScheduler>
 
     private val TAG = "PushNotificationHandler"
 
@@ -28,7 +24,11 @@ class PushNotificationService : FirebaseMessagingService() {
         // For Field Injection
         (applicationContext as AppInjectorProvider).appInjector.inject(this)
         Log.d(TAG, "Initialized?: ${::handlerProvider.isInitialized}")
+        Log.d(TAG, "Scheduler Initialized?: ${::widgetSyncTaskScheduler.isInitialized}")
         Log.d(TAG, "Called")
+
+        // Trigger WidgetSyncTask once FCM arrives
+        widgetSyncTaskScheduler.get().invoke()
     }
 
     override fun onNewToken(token: String) {
@@ -36,14 +36,6 @@ class PushNotificationService : FirebaseMessagingService() {
         (applicationContext as AppInjectorProvider).appInjector.inject(this)
         // POST request to send FCM Token to the Server.
         Log.d(TAG, "onNewToken() call: Received Token: ${token.toString()}")
-
-        // Pending for later version.
-//        val supervisorJob = SupervisorJob()
-//        CoroutineScope(supervisorJob + Dispatchers.IO).launch {
-//            tokenHandler.get().invoke(token)
-//        }.invokeOnCompletion {
-//            supervisorJob.cancel()
-//        }
     }
 
     @RequiresPermission(Manifest.permission.POST_NOTIFICATIONS)

--- a/feature/widget/src/main/java/com/doyoonkim/widget/model/WidgetKey.kt
+++ b/feature/widget/src/main/java/com/doyoonkim/widget/model/WidgetKey.kt
@@ -4,5 +4,5 @@ import androidx.datastore.preferences.core.stringPreferencesKey
 
 object WidgetKey {
     // Key to access Widget's Preference (DataStore)
-    val PREF_STATE_KEY = stringPreferencesKey("PREF_STATE_KEY")
+    val NOTICE_WIDGET_PREF_STATE_KEY = stringPreferencesKey("NOTICE_WIDGET_PREF_STATE_KEY")
 }

--- a/feature/widget/src/main/java/com/doyoonkim/widget/worker/AsyncNoticeWidgetTaskSchedulerImpl.kt
+++ b/feature/widget/src/main/java/com/doyoonkim/widget/worker/AsyncNoticeWidgetTaskSchedulerImpl.kt
@@ -1,0 +1,34 @@
+package com.doyoonkim.widget.worker
+
+import android.content.Context
+import androidx.work.BackoffPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import com.doyoonkim.common.di.ApplicationContext
+import com.doyoonkim.domain.interfaces.AsyncNoticeWidgetTaskScheduler
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+class AsyncNoticeWidgetTaskSchedulerImpl @Inject constructor(
+    @ApplicationContext private val context: Context
+) : AsyncNoticeWidgetTaskScheduler {
+
+    override operator fun invoke() {
+        // Debounced Task Registration.
+        val noticeWidgetTask = OneTimeWorkRequestBuilder<KnuticeWidgetSync>()
+            .setInitialDelay(1, TimeUnit.SECONDS)   // Prevent massive work assigned at the same time.
+            .setBackoffCriteria(
+                backoffPolicy = BackoffPolicy.LINEAR,
+                backoffDelay = 10,
+                timeUnit = TimeUnit.MINUTES
+            )
+            .build()
+
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            uniqueWorkName = "Widget Notice Fetch",
+            existingWorkPolicy = ExistingWorkPolicy.REPLACE,
+            request = noticeWidgetTask
+        )
+    }
+}

--- a/feature/widget/src/main/java/com/doyoonkim/widget/worker/KnuticeWidgetSync.kt
+++ b/feature/widget/src/main/java/com/doyoonkim/widget/worker/KnuticeWidgetSync.kt
@@ -12,7 +12,8 @@ import com.doyoonkim.common.di.AppPreferences
 import com.doyoonkim.common.di.ApplicationContext
 import com.doyoonkim.common.worker.IntermediateWorkerFactory
 import com.doyoonkim.domain.interfaces.NoticeRemoteRepository
-import com.doyoonkim.model.NoticeCategory
+import com.doyoonkim.model.NoticeVO
+import com.doyoonkim.model.WidgetCategoryPolicy
 import com.doyoonkim.widget.model.WidgetKey
 import com.doyoonkim.widget.model.WidgetNoticeVO
 import com.doyoonkim.widget.model.WidgetState
@@ -28,19 +29,21 @@ class KnuticeWidgetSync(
     private val remoteRepository: NoticeRemoteRepository
 ) : CoroutineWorker(appContext, workerParam) {
     private val TAG = "KnuticeWidgetSync"
+    private lateinit var category: String
 
     override suspend fun doWork(): Result {
         Log.d(TAG, "Worker Start")
          // Overall Logic: Fetch -> Debounce -> Validate -> Update -> Complete
-         // Get Current Widget Category Configuration
-         val widgetCategory = appPreferences.getWidgetCategory()
+         // Get Current Widget Category Policy
+         val widgetCategoryPolicy = appPreferences.getWidgetCategoryPolicy()
 
         // If widgetCategory == null -> Set Widget State to Onboarding
-        if (widgetCategory.isNullOrEmpty()) return Result.failure().also { Log.d(TAG, "No selected widget category found.") }
+        if (widgetCategoryPolicy is WidgetCategoryPolicy.Unconfigured)
+            return Result.failure().also { Log.d(TAG, "No selected widget category found.") }
 
         return try {
-            // Get Top Three Notices.
-            val notices = remoteRepository.queryTopThreeNotices(widgetCategory)
+            // Get Top Three Notices, based on the given policy
+            val notices = fetchTopThreeNotice(widgetCategoryPolicy)
 
             Log.d(TAG, "Received: ${notices.toString()}")
             // Unable to fetch notices (receive null or empty)
@@ -60,12 +63,29 @@ class KnuticeWidgetSync(
             }
 
             // Update Widget State (by update cached notices)
-            updateWidgetState(widgetCategory, widgetNotices)
+            updateWidgetState(category, widgetNotices)
             Result.success()
         } catch (e: Exception) {
             Log.d(TAG, "Exception Thrown: ${e.message}")
             // Exception Caught. Terminate Worker.
             if (runAttemptCount < 3) Result.retry() else Result.failure()
+        }
+    }
+
+    // Fetch Corresponding Data
+    private suspend fun fetchTopThreeNotice(policy: WidgetCategoryPolicy): List<NoticeVO>? {
+        when (policy) {
+            is WidgetCategoryPolicy.Main -> {
+                category = policy.categoryKey
+                return remoteRepository.queryTopThreeNotices(policy.categoryKey)
+            }
+            is WidgetCategoryPolicy.Major -> {
+                // Get current subscription status.
+                val subscribedMajor = appPreferences.getSubscribedMajor() ?: return null
+                category = subscribedMajor
+                return remoteRepository.queryTopThreeNotices(subscribedMajor)
+            }
+            else -> { return null }
         }
     }
 
@@ -78,26 +98,49 @@ class KnuticeWidgetSync(
         // Retrieve all glance instance of KnuticeWidget.
         val glanceIds = widgetManager.getGlanceIds(KnuticeWidget::class.java)
 
+        // State Serialization. Serialize it to Json.
+        val currentState = WidgetState(category = category, notices = notices)
+
+        // Flag Variable
+        var isStateChanged = false
+
         glanceIds.forEach { glanceId ->
             // Ensure Thread-safe write to Preference (DataStore)
             updateAppWidgetState(
                 context = appContext,
                 glanceId = glanceId
             ) { preference ->
-                // Serialize to Json
+
+                // Retrieve current state saved in DataStore. (Defensive Json Parsing)
+                val previousState = try {
+                    preference[WidgetKey.NOTICE_WIDGET_PREF_STATE_KEY]?.run {
+                        Json.decodeFromString<WidgetState>(this)
+                            .copy(lastUpdated = 0L)
+                    }
+                } catch (e: Exception) {
+                    // Prevent potential exception when deserialize saved Json after the potential
+                    // structural changes of WidgetState
+                    null
+                }
+                // If there's no state change, terminate function and don't update widget.
+                if (previousState == currentState) return@updateAppWidgetState
+
                 val stateJson = Json.encodeToString(
-                    WidgetState(
-                        category = category,
-                        notices = notices,
-                        lastUpdated = System.currentTimeMillis()
-                    )
+                    currentState.copy(lastUpdated = System.currentTimeMillis())
                 )
+
                 // Update state to Pref (Local Cache)
-                preference[WidgetKey.PREF_STATE_KEY] = stateJson
+                preference[WidgetKey.NOTICE_WIDGET_PREF_STATE_KEY] = stateJson
+                isStateChanged = true
             }
         }
-        // Force Update Glance (Batch Update) (via Inter-Process Communication (IPC) call)
-        KnuticeWidget().updateAll(appContext)
+
+        if (isStateChanged) {
+            // Force Update Glance (Batch Update) (via Inter-Process Communication (IPC) call)
+            KnuticeWidget().updateAll(appContext)
+        } else {
+            Log.d("KnuticeWidgetSync", "No state changes. Update Widget suppressed")
+        }
     }
 
     // Factory


### PR DESCRIPTION
## 📝 Summary (개요)
- Integrate Notice Widget to Actual Service.
## 🔗 Related Issue (관련 이슈)
- Resolves _(if applicable)_ #
- Jira Ticket: [KAN-57]

## 🛠 Type of Change (변경 사항)
- [x] `FEAT`: New feature (새로운 기능)
- [ ] `FIX`: Bug fix (버그 수정)
- [x] `REFACTOR`: Code refactoring (no functional change) (코드 리팩토링)
- [ ] `DESIGN`: UI/UX changes (디자인 변경)
- [ ] `!HOTFIX`: Critical fix (치명적인 버그 수정)
- [ ] `CHORE`: Build/Config/CI (빌드/설정/CI)

## ✨ Key Changes (핵심 변경 사항)
- Define new WidgetCategoryPolicy to handle both Fixed and Dynamic Widget Category selection.
- Define Task Scheduler to provide universal access point to trigger Background Notice Sync Work.
- Corresponding DI configuration.

## 📸 Screenshots / Video (스크린샷 또는 동영상)
- Not applicable

## 🧪 Test Plan (테스트 계획)
- [x] **Scenario**: Trigger WidgetSyncTask -> Corresponding WidgetCategoryPolicy will be stored in SharedPreference after serialization.

## ✅ Checklist (체크리스트)
- [x] My code follows the style guidelines of this project (코드 스타일을 준수했습니다).
- [x] I have performed a self-review of my own code (스스로 코드를 검토했습니다).
- [x] I have commented my code, particularly in hard-to-understand areas (이해하기 어려운 부분에 주석을 작성했습니다).


[KAN-57]: https://knutice.atlassian.net/browse/KAN-57?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ