### PR TITLE
KAN-92 [FEAT] Allow Cafeteria Selection per Push Notification.

### DIFF
--- a/app/src/main/java/com/doyoonkim/knutice/navigation/campusServiceGraph.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/navigation/campusServiceGraph.kt
@@ -113,10 +113,10 @@ fun NavGraphBuilder.campusServiceGraph(
         }
     ) { backStackEntry ->
         val selection = backStackEntry.arguments?.getString("mealTopic")
-        Log.d("Navigation", "Dining Hall Selection: ")
 
         DiningMenuScreen(
-            modifier = Modifier
+            modifier = Modifier,
+            hallSelection = selection ?: ""
         ) {
             navController.popBackStack()
         }

--- a/feature/main/build.gradle.kts
+++ b/feature/main/build.gradle.kts
@@ -27,12 +27,14 @@ configure<LibraryExtension>() {
     val carrelBridge = properties["carrel_bridge"] ?: ""
 
     val diningPath = properties["dining_path"] ?: ""
+    val diningBridge = properties["dining_bridge"] ?: ""
 
     defaultConfig {
         buildConfigField("String", "KNUTICE_ORIGIN", "\"$origin\"")
         buildConfigField("String", "CARREL_PATH", "\"$carrelPath\"")
         buildConfigField("String", "CARREL_BRIDGE", "\"$carrelBridge\"")
         buildConfigField("String", "DINING_PATH", "\"$diningPath\"")
+        buildConfigField("String", "DINING_BRIDGE", "\"$diningBridge\"")
     }
 
     buildFeatures {

--- a/feature/main/src/main/java/com/doyoonkim/main/campus/meal/DiningMenuScreen.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/campus/meal/DiningMenuScreen.kt
@@ -1,10 +1,16 @@
 package com.doyoonkim.main.campus.meal
 
+import android.webkit.WebView
+import android.webkit.WebViewClient
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.padding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import com.doyoonkim.common.theme.displayBackground
 import com.doyoonkim.common.ui.TopAppBarWithNavButton
@@ -14,8 +20,31 @@ import com.doyoonkim.main.campus.components.LifecycleAwareWebView
 @Composable
 fun DiningMenuScreen(
     modifier: Modifier = Modifier,
+    hallSelection: String = "",
     onBackClicked: () -> Unit = {  }
 ) {
+
+    var isHallSelectionProvided by remember { mutableStateOf(false) }
+
+    // WebViewClient
+    val diningWebViewClient = remember {
+        object: WebViewClient() {
+            override fun onPageFinished(view: WebView?, url: String?) {
+                // Check hallSelection is provided.
+                if (hallSelection.isNotBlank() && !isHallSelectionProvided) {
+                    val call = BuildConfig.DINING_BRIDGE + "('$hallSelection');"
+
+                    // JS Injection
+                    view?.evaluateJavascript("""
+                        $call
+                    """.trimIndent(), null)
+                    isHallSelectionProvided = true
+                }
+                super.onPageFinished(view, url)
+            }
+        }
+    }
+
     Scaffold(
         modifier = modifier,
         topBar = {
@@ -33,6 +62,9 @@ fun DiningMenuScreen(
                 .fillMaxSize()
                 .padding(contentPadding),
             url = BuildConfig.KNUTICE_ORIGIN + BuildConfig.DINING_PATH,
+            onWebViewCreate = { webView ->
+                webView.webViewClient = diningWebViewClient
+            },
             onLeaveWebView = {
                 // System Back Button/Gesture Handling
                 onBackClicked()


### PR DESCRIPTION
## 📝 Summary (개요)
- Allow user to directly navigate to related Dining menu based on the Push Notificaiton Clicked.
## 🔗 Related Issue (관련 이슈)
- Resolves _(if applicable)_ #
- Jira Ticket: [KAN-92]
- Resolved Problem: [[학식 웹뷰] Android 클라이언트에서 Bridge Function을 통한 학식 선택 전환 불가 #1](https://github.com/KNUTICE/KNUTICE-CLIENT/issues/1)

## 🛠 Type of Change (변경 사항)
- [x] `FEAT`: New feature (새로운 기능)
- [ ] `FIX`: Bug fix (버그 수정)
- [ ] `REFACTOR`: Code refactoring (no functional change) (코드 리팩토링)
- [ ] `DESIGN`: UI/UX changes (디자인 변경)
- [ ] `!HOTFIX`: Critical fix (치명적인 버그 수정)
- [ ] `CHORE`: Build/Config/CI (빌드/설정/CI)

## ✨ Key Changes (핵심 변경 사항)
- Allow Meals Web Application switch the menu tab automatically based on the URI used to access the DiningScreen.

## 📸 Screenshots / Video (스크린샷 또는 동영상)
| Access Dining Menu via Deeplink (Staff Cafeteria) |
|:---:|
| <video src="https://github.com/user-attachments/assets/c1c5404d-8fef-4e6c-9190-61c46d4f8c2f" width="400px" />

## 🧪 Test Plan (테스트 계획)
- [x] **Device**: Android Emulator (Pixel 9 Pro, SDK 36) 
- [x] **Scenario**: Send the test Meal notification -> Click received push notification to enter the application -> Navigated to DiningMenuScreen -> Corresponding Dining Hall is selected automatically.

## ✅ Checklist (체크리스트)
- [x] My code follows the style guidelines of this project (코드 스타일을 준수했습니다).
- [x] I have performed a self-review of my own code (스스로 코드를 검토했습니다).
- [x] I have commented my code, particularly in hard-to-understand areas (이해하기 어려운 부분에 주석을 작성했습니다).


[KAN-92]: https://knutice.atlassian.net/browse/KAN-92?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ