### PR TITLE
[FEAT] Reading Room Widget Implementation

### DIFF
--- a/app/src/main/java/com/doyoonkim/knutice/di/components/AppComponent.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/di/components/AppComponent.kt
@@ -14,6 +14,7 @@ import com.doyoonkim.knutice.di.modules.WorkerModule
 import com.doyoonkim.network.di.NetworkModule
 import com.doyoonkim.notification.di.FcmTokenModule
 import com.doyoonkim.common.worker.IntermediateWorkerFactory
+import com.doyoonkim.data.di.CampusRemoteModule
 import com.doyoonkim.data.di.NoticeRemoteModule
 import com.doyoonkim.data.di.RoomDatabaseModule
 import com.doyoonkim.data.di.SystemCoroutineModule
@@ -77,6 +78,7 @@ interface AppComponent :
         TokenRemoteModule::class,
         AsyncFtsEntryInsertionModule::class,
         NoticeRemoteModule::class,
+        CampusRemoteModule::class
     ]
 )
 interface WorkerSubcomponent {

--- a/core/data/src/main/java/com/doyoonkim/data/di/RemoteModules.kt
+++ b/core/data/src/main/java/com/doyoonkim/data/di/RemoteModules.kt
@@ -1,7 +1,9 @@
 package com.doyoonkim.data.di
 
+import com.doyoonkim.data.repository.CampusRemoteRepository
 import com.doyoonkim.data.repository.ImageRepositoryImpl
 import com.doyoonkim.data.repository.RemoteRepositoryImpl
+import com.doyoonkim.domain.interfaces.CarrelStatusRemoteRepository
 import com.doyoonkim.domain.interfaces.ImageRemoteRepository
 import com.doyoonkim.domain.interfaces.NoticeRemoteRepository
 import com.doyoonkim.domain.interfaces.TipRemoteRepository
@@ -54,4 +56,12 @@ abstract class ImageRemoteModule {
     abstract fun bindsImageRemoteRepo(
         impl: ImageRepositoryImpl
     ) : ImageRemoteRepository
+}
+
+@Module
+abstract class CampusRemoteModule {
+    @Binds
+    abstract fun bindsCarrelRoomRemoteRepo(
+        impl: CampusRemoteRepository
+    ): CarrelStatusRemoteRepository
 }

--- a/core/data/src/main/java/com/doyoonkim/data/repository/CampusRemoteRepository.kt
+++ b/core/data/src/main/java/com/doyoonkim/data/repository/CampusRemoteRepository.kt
@@ -1,0 +1,49 @@
+package com.doyoonkim.data.repository
+
+import android.util.Log
+import com.doyoonkim.domain.interfaces.CarrelStatusRemoteRepository
+import com.doyoonkim.model.CarrelRoomStatusVO
+import com.doyoonkim.network.KnuticeRemoteSource
+import com.doyoonkim.network.util.NetworkResultUtil
+import model.Metadata
+import javax.inject.Inject
+
+
+class CampusRemoteRepository @Inject constructor(
+    private val remoteSource: KnuticeRemoteSource
+): CarrelStatusRemoteRepository {
+    companion object {
+        private val TAG = "CampusRemoteRepository"
+    }
+
+    override suspend fun getCarrelRoomStatus(): Result<List<CarrelRoomStatusVO>> {
+        remoteSource.getCarrelRoomStatus().fold(
+            onSuccess = { response ->
+                if (response.result == null)
+                    Log.d(TAG, "Unable to receive data").also {
+                        return Result.failure(Exception("Unable to receive data"))
+                    }
+
+                if (response.result?.resultCode == 200) {
+                    return Result.success(response.body?.map { dto -> dto.toVO() } ?: emptyList())
+                } else {
+                    response.result?.printLog()
+                    return Result.failure( NetworkResultUtil.resultCodeValidator(response.result))
+                }
+            },
+            onFailure = {
+                it.printLog()
+                return Result.failure(it)
+            }
+        )
+    }
+
+    private fun Throwable.printLog() =
+        Log.d(TAG, "Failed to receive data\nREASON: ${this.stackTraceToString()}")
+
+    private fun Metadata?.printLog() =
+        Log.d(TAG, "Failed to receive data (${this?.resultCode})" +
+                "\nREASON:${this?.resultMessage}")
+
+
+}

--- a/core/domain/src/main/java/com/doyoonkim/domain/interfaces/CarrelStatusRemoteRepository.kt
+++ b/core/domain/src/main/java/com/doyoonkim/domain/interfaces/CarrelStatusRemoteRepository.kt
@@ -1,0 +1,10 @@
+package com.doyoonkim.domain.interfaces
+
+import com.doyoonkim.model.CarrelRoomStatusVO
+
+
+interface CarrelStatusRemoteRepository {
+
+    suspend fun getCarrelRoomStatus(): Result<List<CarrelRoomStatusVO>>
+
+}

--- a/core/model/src/main/java/com/doyoonkim/model/CarrelRoomStatusVO.kt
+++ b/core/model/src/main/java/com/doyoonkim/model/CarrelRoomStatusVO.kt
@@ -1,0 +1,10 @@
+package com.doyoonkim.model
+
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CarrelRoomStatusVO(
+    val name: String = "",
+    val total: Int = 0,
+    val occupied: Int = 0
+)

--- a/core/model/src/main/java/com/doyoonkim/model/util/KnuticeNetworkException.kt
+++ b/core/model/src/main/java/com/doyoonkim/model/util/KnuticeNetworkException.kt
@@ -1,0 +1,15 @@
+package com.doyoonkim.model.util
+
+
+sealed class KnuticeNetworkException: Throwable() {
+
+    // General Exception (100 - 199, 300 - 399)
+    data class GeneralException(val code: Int, val reason: String): KnuticeNetworkException()
+
+    // Client-Side Exception (400 - 499)
+    data class ClientSideException(val code: Int, val reason: String): KnuticeNetworkException()
+
+    // Server-Side Exception (500 - 599)
+    data class ServerSideException(val code: Int, val reason: String): KnuticeNetworkException()
+
+}

--- a/core/network/src/main/kotlin/com/doyoonkim/network/KnuticeRemoteSource.kt
+++ b/core/network/src/main/kotlin/com/doyoonkim/network/KnuticeRemoteSource.kt
@@ -60,6 +60,15 @@ class KnuticeRemoteSource @Inject constructor(
         knuticeApi.getAllTips(deviceType = "AOS")
     }
 
+    suspend fun getCarrelRoomStatus() = runCatching {
+        if (appPreference.getCachedToken().isNullOrBlank()) throw Exception("No validated token found")
+        else {
+            knuticeApi.getReadingRoomStatus(
+                appPreference.getCachedToken()!!
+            )
+        }
+    }
+
     suspend fun validateToken(token: String, request: FcmTokenSaveRequest) = runCatching {
             if (appPreference.getCachedToken().isNullOrBlank() || appPreference.getCachedToken() != token) {
                 throw Exception("Token Mismatch\nReceived: $token Cached: ${appPreference.getCachedToken()}")

--- a/core/network/src/main/kotlin/com/doyoonkim/network/model/Responses.kt
+++ b/core/network/src/main/kotlin/com/doyoonkim/network/model/Responses.kt
@@ -1,6 +1,7 @@
 package model
 
 import androidx.annotation.Keep
+import com.doyoonkim.network.model.dto.CarrelRoomStatusDTO
 import com.doyoonkim.network.model.dto.NoticeSummaryDTO
 import com.doyoonkim.network.model.dto.TipDTO
 import com.doyoonkim.network.model.dto.TopicSubscriptionStatusDTO
@@ -72,4 +73,10 @@ data class PatchResult(
 data class TipResult(
     @SerializedName("metaData") var result: Metadata? = Metadata(),
     @SerializedName("data") var body: ArrayList<TipDTO>? = null
+)
+
+@Keep
+data class ReadingRoomStatusResult(
+    @SerializedName("metaData") var result: Metadata? = Metadata(),
+    @SerializedName("data") var body: ArrayList<CarrelRoomStatusDTO>? = null
 )

--- a/core/network/src/main/kotlin/com/doyoonkim/network/model/dto/CarrelRoomStatusDTO.kt
+++ b/core/network/src/main/kotlin/com/doyoonkim/network/model/dto/CarrelRoomStatusDTO.kt
@@ -1,0 +1,23 @@
+package com.doyoonkim.network.model.dto
+
+import androidx.annotation.Keep
+import com.doyoonkim.model.CarrelRoomStatusVO
+import com.google.gson.annotations.SerializedName
+
+@Keep
+data class CarrelRoomStatusDTO(
+    @SerializedName("roomId") var id: String? = null,
+    @SerializedName("roomName") var name: String? = null,
+    @SerializedName("totalSeat") var total: Int? = null,
+    @SerializedName("availableSeat") var available: Int? = null,
+    @SerializedName("occupiedSeat") var occupied: Int? = null,
+    @SerializedName("rowCount") var rowCount: Int? = null,
+    @SerializedName("columnCount") var columnCount: Int? = null
+) {
+    fun toVO() =
+        CarrelRoomStatusVO(
+            name = this.name ?: "",
+            total = this.total ?: 0,
+            occupied = this.occupied ?: 0
+        )
+}

--- a/core/network/src/main/kotlin/com/doyoonkim/network/retrofit/KnuticeService.kt
+++ b/core/network/src/main/kotlin/com/doyoonkim/network/retrofit/KnuticeService.kt
@@ -4,12 +4,14 @@ import com.doyoonkim.network.model.FcmTokenSaveRequest
 import com.doyoonkim.network.model.FcmTokenUpdateRequest
 import com.doyoonkim.network.model.ReportSaveRequest
 import com.doyoonkim.network.model.TopicUpdateRequest
+import com.doyoonkim.network.model.dto.CarrelRoomStatusDTO
 import model.NoticeByIdResult
 import model.NoticeSummaryResult
 import model.NoticesByKeywordResult
 import model.NoticesPerPageResult
 import model.PatchResult
 import model.PostResult
+import model.ReadingRoomStatusResult
 import model.TipResult
 import model.TopicSubscriptionPreferencesResult
 import retrofit2.http.Body
@@ -61,6 +63,11 @@ interface KnuticeService {
     suspend fun getAllTips(
         @Query("deviceType") deviceType: String
     ): TipResult
+
+    @GET("open-api/v1/reading-rooms/status")
+    suspend fun getReadingRoomStatus(
+        @Header("fcmToken") token: String
+    ): ReadingRoomStatusResult
 
     @Headers("Content-Type: application/json")
     @POST("open-api/v1/fcm-tokens")

--- a/core/network/src/main/kotlin/com/doyoonkim/network/util/NetworkResultUtil.kt
+++ b/core/network/src/main/kotlin/com/doyoonkim/network/util/NetworkResultUtil.kt
@@ -1,0 +1,25 @@
+package com.doyoonkim.network.util
+
+import com.doyoonkim.model.util.KnuticeNetworkException
+import model.Metadata
+
+/**
+ * @author kimdoyoon
+ * Created 3/1/26 at 6:57 PM
+ */
+object NetworkResultUtil {
+
+    fun resultCodeValidator(result: Metadata?): Throwable {
+        val resultCode = result?.resultCode ?: 0
+        val reason = result?.resultMessage ?: "Unknown Reason"
+
+        return when (resultCode) {
+            in 400..499 -> KnuticeNetworkException.ClientSideException(resultCode, reason)
+            in 500..599 -> KnuticeNetworkException.ServerSideException(resultCode, reason)
+            else -> {
+                KnuticeNetworkException.GeneralException(resultCode, reason)
+            }
+        }
+    }
+
+}

--- a/feature/widget/src/main/java/com/doyoonkim/widget/di/WidgetModule.kt
+++ b/feature/widget/src/main/java/com/doyoonkim/widget/di/WidgetModule.kt
@@ -2,6 +2,7 @@ package com.doyoonkim.widget.di
 
 import com.doyoonkim.common.di.WorkerKey
 import com.doyoonkim.common.worker.IntermediateWorkerFactory
+import com.doyoonkim.widget.worker.KnuticeCarrelWidgetSync
 import com.doyoonkim.widget.worker.KnuticeWidgetSync
 import dagger.Binds
 import dagger.Module
@@ -15,6 +16,13 @@ abstract class WidgetModule {
     @WorkerKey(KnuticeWidgetSync::class)
     abstract fun bindsKnuticeWidgetSyncWorker(
         factory: KnuticeWidgetSync.Factory
+    ): IntermediateWorkerFactory
+
+    @Binds
+    @IntoMap
+    @WorkerKey(KnuticeCarrelWidgetSync::class)
+    abstract fun bindsKnuticeCarrelWidgetSyncWorker(
+        factory: KnuticeCarrelWidgetSync.Factory
     ): IntermediateWorkerFactory
 
 }

--- a/feature/widget/src/main/java/com/doyoonkim/widget/model/CarrelWidgetState.kt
+++ b/feature/widget/src/main/java/com/doyoonkim/widget/model/CarrelWidgetState.kt
@@ -1,0 +1,9 @@
+package com.doyoonkim.widget.model
+
+import com.doyoonkim.model.CarrelRoomStatusVO
+import kotlinx.serialization.Serializable
+
+@Serializable
+data class CarrelWidgetState(
+    val status: List<CarrelRoomStatusVO> = emptyList()
+)

--- a/feature/widget/src/main/java/com/doyoonkim/widget/model/WidgetKey.kt
+++ b/feature/widget/src/main/java/com/doyoonkim/widget/model/WidgetKey.kt
@@ -1,8 +1,15 @@
 package com.doyoonkim.widget.model
 
+import androidx.datastore.preferences.core.booleanPreferencesKey
+import androidx.datastore.preferences.core.floatPreferencesKey
+import androidx.datastore.preferences.core.longPreferencesKey
 import androidx.datastore.preferences.core.stringPreferencesKey
 
 object WidgetKey {
     // Key to access Widget's Preference (DataStore)
     val NOTICE_WIDGET_PREF_STATE_KEY = stringPreferencesKey("NOTICE_WIDGET_PREF_STATE_KEY")
+    val CARREL_WIDGET_PREF_STATE_KEY = stringPreferencesKey("CARREL_WIDGET_PREF_STATE_KEY")
+    val CARREL_WIDGET_PREF_LAST_SYNC_KEY = longPreferencesKey("CARREL_WIDGET_PREF_LAST_SYNC_KEY")
+    val CARREL_WIDGET_PREF_LOADING_STATE_KEY = booleanPreferencesKey("CARREL_WIDGET_PREF_LOADING_STATE_KEY")
+    val CARREL_WIDGET_PREF_CACHE_KEY = stringPreferencesKey("CARREL_WIDGET_PREF_CACHE_KEY")
 }

--- a/feature/widget/src/main/java/com/doyoonkim/widget/worker/CarrelWidgetTaskScheduler.kt
+++ b/feature/widget/src/main/java/com/doyoonkim/widget/worker/CarrelWidgetTaskScheduler.kt
@@ -1,0 +1,31 @@
+package com.doyoonkim.widget.worker
+
+import android.content.Context
+import androidx.work.BackoffPolicy
+import androidx.work.ExistingWorkPolicy
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.OutOfQuotaPolicy
+import androidx.work.WorkManager
+import java.util.concurrent.TimeUnit
+
+// Bypass Dagger's Dependency tree for Scheduler Instance only.
+// Kotlin-wise Singleton Instance would be provided.
+object CarrelWidgetTaskScheduler {
+    fun schedule(context: Context) {
+        // Apply Debounce (since the manual scheduling is enabled.)
+        val carrelStatusTask = OneTimeWorkRequestBuilder<KnuticeCarrelWidgetSync>()
+            .setExpedited(OutOfQuotaPolicy.RUN_AS_NON_EXPEDITED_WORK_REQUEST)
+            .setBackoffCriteria(
+                backoffPolicy = BackoffPolicy.EXPONENTIAL,
+                backoffDelay = 30,
+                timeUnit = TimeUnit.SECONDS
+            )
+            .build()
+
+        WorkManager.getInstance(context).enqueueUniqueWork(
+            uniqueWorkName = "Carrel Room Status Widget Sync",
+            existingWorkPolicy = ExistingWorkPolicy.REPLACE,        // Enable debounce.
+            request = carrelStatusTask
+        )
+    }
+}

--- a/feature/widget/src/main/java/com/doyoonkim/widget/worker/KnuticeCarrelWidgetSync.kt
+++ b/feature/widget/src/main/java/com/doyoonkim/widget/worker/KnuticeCarrelWidgetSync.kt
@@ -1,0 +1,125 @@
+package com.doyoonkim.widget.worker
+
+import android.content.Context
+import android.util.Log
+import androidx.glance.appwidget.GlanceAppWidgetManager
+import androidx.glance.appwidget.state.updateAppWidgetState
+import androidx.glance.appwidget.updateAll
+import androidx.work.CoroutineWorker
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
+import com.doyoonkim.common.worker.IntermediateWorkerFactory
+import com.doyoonkim.domain.interfaces.CarrelStatusRemoteRepository
+import com.doyoonkim.model.CarrelRoomStatusVO
+import com.doyoonkim.model.di.ApplicationContext
+import com.doyoonkim.widget.carrel.KnuticeCarrelRoomStatusWidget
+import com.doyoonkim.widget.model.CarrelWidgetState
+import com.doyoonkim.widget.model.WidgetKey
+import kotlinx.serialization.encodeToString
+import kotlinx.serialization.json.Json
+import javax.inject.Inject
+
+class KnuticeCarrelWidgetSync(
+    private val appContext: Context,
+    workerParam: WorkerParameters,
+    private val repository: CarrelStatusRemoteRepository
+): CoroutineWorker(appContext, workerParam) {
+    companion object {
+        private val TAG = "KnuticeCarrelWidgetSync"
+        private val json = Json {
+            encodeDefaults = true
+            ignoreUnknownKeys = true
+        }
+    }
+
+    override suspend fun doWork(): Result {
+        // Fetch Current status
+        Log.d(TAG, "Carrel Widget Worker Start")
+
+        return repository.getCarrelRoomStatus()
+            .fold(
+                onSuccess = { status ->
+                    Log.d(TAG, "${status.toString()}")
+                    setWidgetLoading()
+                    updateWidgetState(status)
+                    Result.success()
+                },
+                onFailure = {reason ->
+                    if (runAttemptCount < 3) Result.retry()
+                    else Result.failure().also { Log.d(TAG, "Error: ${reason.stackTraceToString()}") }
+                }
+            )
+    }
+
+    private suspend fun setWidgetLoading() {
+        val widgetManager = GlanceAppWidgetManager(appContext)
+        val glanceIds = widgetManager.getGlanceIds(KnuticeCarrelRoomStatusWidget::class.java)
+
+        glanceIds.forEach { glanceId ->
+            updateAppWidgetState(
+                context = appContext,
+                glanceId = glanceId
+            ) { preferences ->
+                preferences[WidgetKey.CARREL_WIDGET_PREF_LOADING_STATE_KEY] = true
+            }
+        }
+        // Widget Loading State update. (Tiny IPC communication)
+        KnuticeCarrelRoomStatusWidget().updateAll(appContext)
+    }
+
+    private suspend fun updateWidgetState(status: List<CarrelRoomStatusVO>) {
+        // Current Status
+        val currentStatus = status.joinToString { "${it.name}:${it.occupied}" }
+
+        // Widget manager
+        val widgetManager = GlanceAppWidgetManager(appContext)
+        // Retrieve all CarrelWidget instance
+        val glanceId = widgetManager.getGlanceIds(KnuticeCarrelRoomStatusWidget::class.java)
+
+        glanceId.forEach { glanceId ->
+            // Ensure Thread-safe write to Preference (DataStore)
+            updateAppWidgetState(
+                context = appContext,
+                glanceId = glanceId,
+            ) { preferences ->
+                // Set Loading State and Last Updated Mark
+                val syncTimeStamp = System.currentTimeMillis()
+                preferences[WidgetKey.CARREL_WIDGET_PREF_LOADING_STATE_KEY] = false
+                preferences[WidgetKey.CARREL_WIDGET_PREF_LAST_SYNC_KEY] = syncTimeStamp
+
+                // Get Cached Status
+                val cachedStatus = preferences[WidgetKey.CARREL_WIDGET_PREF_CACHE_KEY]
+                if (cachedStatus != currentStatus) {
+                    Log.d(TAG, "Core data has been changed. Apply changes to Payload")
+                    val carrelWidgetState = CarrelWidgetState(
+                        status = status
+                    )
+                    // Update state to Pref
+                    preferences[WidgetKey.CARREL_WIDGET_PREF_STATE_KEY] =
+                        json.encodeToString(carrelWidgetState)
+                    // Update Cached Value
+                    preferences[WidgetKey.CARREL_WIDGET_PREF_CACHE_KEY] = currentStatus
+                } else {
+                    Log.d(TAG, "Core Data Identical. Only Metadata would be updated.")
+                }
+            }
+        }
+
+        // If only Metadata has changed, IPC communication would be very tiny (< 1KB)
+        KnuticeCarrelRoomStatusWidget().updateAll(appContext)
+    }
+
+    // Factory
+    class Factory @Inject constructor(
+        @ApplicationContext private val context: Context,
+        private val repository: CarrelStatusRemoteRepository
+    ): IntermediateWorkerFactory {
+        override fun create(params: WorkerParameters): ListenableWorker {
+            return KnuticeCarrelWidgetSync(
+                context, params, repository
+            )
+        }
+
+    }
+
+}


### PR DESCRIPTION
## 📝 Summary (개요)
- Implement Reading Room Widget to allow user to check current Reading Room occupancy status in glance.
- Necessary back-end side logic has been defined (repository, API access point, and Background Task)
## 🔗 Related Issue (관련 이슈)
- Resolves _(if applicable)_ #
- Jira Ticket: [KAN-103]

## 🛠 Type of Change (변경 사항)
- [x] `FEAT`: New feature (새로운 기능)
- [ ] `FIX`: Bug fix (버그 수정)
- [ ] `REFACTOR`: Code refactoring (no functional change) (코드 리팩토링)
- [ ] `DESIGN`: UI/UX changes (디자인 변경)
- [ ] `!HOTFIX`: Critical fix (치명적인 버그 수정)
- [ ] `CHORE`: Build/Config/CI (빌드/설정/CI)

## ✨ Key Changes (핵심 변경 사항)
- Defined Back-end side logic (API access point, repository, background task) has been defined.
- Register corresponding classes to Dagger Dependency Graph.
- (Exception) Let CarrelWidgetSyncTaskScheduler to bypass Dagger's Dependency graph. (Managed manually.)

## 📸 Screenshots / Video (스크린샷 또는 동영상)
- Not applicable

## 🧪 Test Plan (테스트 계획)
- Not applicable

## ✅ Checklist (체크리스트)
- [x] My code follows the style guidelines of this project (코드 스타일을 준수했습니다).
- [x] I have performed a self-review of my own code (스스로 코드를 검토했습니다).
- [x] I have commented my code, particularly in hard-to-understand areas (이해하기 어려운 부분에 주석을 작성했습니다).


[KAN-103]: https://knutice.atlassian.net/browse/KAN-103?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ