### PR TITLE
[REFACTOR] Apply Robust Staging Table Strategy.

### DIFF
--- a/app/src/main/java/com/doyoonkim/knutice/task/AsyncFtsTableInsertion.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/task/AsyncFtsTableInsertion.kt
@@ -32,7 +32,7 @@ class AsyncFtsTableInsertion(
             for (e in batchResult) {
                 val insertionResult = insertPendingFtsEntries.execute(e)
                 if (insertionResult) {
-                    processedId.add(e.bookmarkId)
+                    processedId.add(e.stagingId)
                 }
             }
             val result = localRepository.removePendingBookmarkFtsEntry(processedId).first()

--- a/core/data/schemas/com.doyoonkim.data.room.LocalDatabase/5.json
+++ b/core/data/schemas/com.doyoonkim.data.room.LocalDatabase/5.json
@@ -1,0 +1,225 @@
+{
+  "formatVersion": 1,
+  "database": {
+    "version": 5,
+    "identityHash": "7617cc460ee3ef2c5b1ab1b371b3f85d",
+    "entities": [
+      {
+        "tableName": "Bookmark",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`bookmarkId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `isScheduled` INTEGER NOT NULL, `remind_schedule` INTEGER NOT NULL, `bookmark_note` TEXT NOT NULL, `target_ntt_id` INTEGER NOT NULL, `created_at` INTEGER NOT NULL, `updated_at` INTEGER NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "bookmarkId",
+            "columnName": "bookmarkId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "isScheduled",
+            "columnName": "isScheduled",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "reminderSchedule",
+            "columnName": "remind_schedule",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "note",
+            "columnName": "bookmark_note",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nttId",
+            "columnName": "target_ntt_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "created_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "updatedAt",
+            "columnName": "updated_at",
+            "affinity": "INTEGER",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "bookmarkId"
+          ]
+        }
+      },
+      {
+        "tableName": "NoticeEntity",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`noticeEntityId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL, `ntt_id` INTEGER NOT NULL, `notice_title` TEXT NOT NULL, `notice_url` TEXT NOT NULL, `notice_image` TEXT NOT NULL, `info_dept` TEXT NOT NULL, `info_timestamp` TEXT NOT NULL, `notice_category` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "noticeEntityId",
+            "columnName": "noticeEntityId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "nttId",
+            "columnName": "ntt_id",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "title",
+            "columnName": "notice_title",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "url",
+            "columnName": "notice_url",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "imageUrl",
+            "columnName": "notice_image",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "departName",
+            "columnName": "info_dept",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "timestamp",
+            "columnName": "info_timestamp",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noticeCategory",
+            "columnName": "notice_category",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "noticeEntityId"
+          ]
+        }
+      },
+      {
+        "tableName": "BookmarkFts",
+        "createSql": "CREATE VIRTUAL TABLE IF NOT EXISTS `${TABLE_NAME}` USING FTS4(`bookmarkNotes` TEXT NOT NULL, `noticeTitle` TEXT NOT NULL, `bookmarkNoteTokenized` TEXT NOT NULL, `noticeTitleTokenized` TEXT NOT NULL)",
+        "fields": [
+          {
+            "fieldPath": "bookmarkNotes",
+            "columnName": "bookmarkNotes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noticeTitle",
+            "columnName": "noticeTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkNoteTokenized",
+            "columnName": "bookmarkNoteTokenized",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noticeTitleTokenized",
+            "columnName": "noticeTitleTokenized",
+            "affinity": "TEXT",
+            "notNull": true
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "rowid"
+          ]
+        },
+        "ftsVersion": "FTS4",
+        "ftsOptions": {
+          "tokenizer": "simple",
+          "tokenizerArgs": [],
+          "contentTable": "",
+          "languageIdColumnName": "",
+          "matchInfo": "FTS4",
+          "notIndexedColumns": [],
+          "prefixSizes": [],
+          "preferredOrder": "ASC"
+        },
+        "contentSyncTriggers": []
+      },
+      {
+        "tableName": "PendingBookmarkFtsAsync",
+        "createSql": "CREATE TABLE IF NOT EXISTS `${TABLE_NAME}` (`stagingId` INTEGER PRIMARY KEY AUTOINCREMENT NOT NULL DEFAULT 0, `bookmarkId` INTEGER NOT NULL, `bookmarkNotes` TEXT NOT NULL, `noticeTitle` TEXT NOT NULL, `createdAt` INTEGER NOT NULL, `stagingPolicy` TEXT NOT NULL DEFAULT 'INSERT')",
+        "fields": [
+          {
+            "fieldPath": "stagingId",
+            "columnName": "stagingId",
+            "affinity": "INTEGER",
+            "notNull": true,
+            "defaultValue": "0"
+          },
+          {
+            "fieldPath": "bookmarkId",
+            "columnName": "bookmarkId",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "bookmarkNotes",
+            "columnName": "bookmarkNotes",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "noticeTitle",
+            "columnName": "noticeTitle",
+            "affinity": "TEXT",
+            "notNull": true
+          },
+          {
+            "fieldPath": "createdAt",
+            "columnName": "createdAt",
+            "affinity": "INTEGER",
+            "notNull": true
+          },
+          {
+            "fieldPath": "stagingPolicy",
+            "columnName": "stagingPolicy",
+            "affinity": "TEXT",
+            "notNull": true,
+            "defaultValue": "'INSERT'"
+          }
+        ],
+        "primaryKey": {
+          "autoGenerate": true,
+          "columnNames": [
+            "stagingId"
+          ]
+        }
+      }
+    ],
+    "setupQueries": [
+      "CREATE TABLE IF NOT EXISTS room_master_table (id INTEGER PRIMARY KEY,identity_hash TEXT)",
+      "INSERT OR REPLACE INTO room_master_table (id,identity_hash) VALUES(42, '7617cc460ee3ef2c5b1ab1b371b3f85d')"
+    ]
+  }
+}

--- a/core/data/src/main/java/com/doyoonkim/data/model/Bookmark.kt
+++ b/core/data/src/main/java/com/doyoonkim/data/model/Bookmark.kt
@@ -4,6 +4,7 @@ import androidx.room.ColumnInfo
 import androidx.room.Entity
 import androidx.room.Fts4
 import androidx.room.PrimaryKey
+import com.doyoonkim.model.StagingPolicy
 
 @Entity
 data class Bookmark(
@@ -30,8 +31,11 @@ data class BookmarkFts(
 // Temporary Table for Asynchronous FTS table insertion
 @Entity
 data class PendingBookmarkFtsAsync(
-    @PrimaryKey val bookmarkId: Int,
+    @PrimaryKey(autoGenerate = true)
+    @ColumnInfo(defaultValue = "0") val stagingId: Int = 0,
+    val bookmarkId: Int,
     val bookmarkNotes: String,
     val noticeTitle: String,
-    val createdAt: Long = System.currentTimeMillis()
+    val createdAt: Long = System.currentTimeMillis(),
+    @ColumnInfo(defaultValue = "INSERT")val stagingPolicy: StagingPolicy
 )

--- a/core/data/src/main/java/com/doyoonkim/data/repository/LocalRepositoryImpl.kt
+++ b/core/data/src/main/java/com/doyoonkim/data/repository/LocalRepositoryImpl.kt
@@ -1,12 +1,13 @@
 package com.doyoonkim.data.repository
 
 import android.util.Log
+import androidx.room.withTransaction
 import com.doyoonkim.data.model.Bookmark
 import com.doyoonkim.data.model.BookmarkAsListElement
 import com.doyoonkim.data.model.BookmarkFts
 import com.doyoonkim.data.model.NoticeEntity
 import com.doyoonkim.data.model.PendingBookmarkFtsAsync
-import com.doyoonkim.data.room.MainDatabaseDao
+import com.doyoonkim.data.room.LocalDatabase
 import com.doyoonkim.domain.SortOption
 import com.doyoonkim.domain.interfaces.BookmarkLocalRepository
 import com.doyoonkim.domain.interfaces.NoticeLocalRepository
@@ -20,42 +21,56 @@ import kotlinx.coroutines.flow.flow
 import javax.inject.Inject
 
 class LocalRepositoryImpl @Inject constructor(
-    // Inject Local Database from the app module (planned)
-    private val localDao: MainDatabaseDao
+    private val database: LocalDatabase
 ) : BookmarkLocalRepository, NoticeLocalRepository {
     private val TAG = "LocalRepositoryImpl"
+    private val localDao = database.getDao()
 
     // CRUD
-    override fun createBookmark(bookmark: BookmarkVO) = flow {
-        runCatching {
-            localDao.createBookmark(bookmark.toBookmark())
-        }.onFailure { throw it }.fold(
-            onSuccess = { emit(true) },
-            onFailure = { it.printLog().also { emit(false) } }
-        )
-    }
+    override suspend fun createBookmark(
+        bookmark: BookmarkVO,
+        targetNotice: NoticeVO,
+        pending: PendingBookmarkFtsVO
+    ): Boolean {
+        return try {
+            // Ensure Atomicity in Sequential DB Operations
+            database.withTransaction {
+                // Insert Notice Locally
+                localDao.createNoticeEntity(targetNotice.toNoticeEntity())
+                // Insert Bookmark Entity
+                localDao.createBookmark(bookmark.toBookmark())
+                // Insert Pending Entity to Staging Table
+                localDao.createAsyncFtsEntity(pending.toEntry())
 
-    override fun createBookmark(bookmark: BookmarkVO, targetNotice: NoticeVO) = flow {
-        runCatching {
-            localDao.run {
-                // Insert Notice Entity First
-                createNoticeEntity(targetNotice.toNoticeEntity())
-                // Insert Bookmark Entity next.
-                this.createBookmark(bookmark.toBookmark())
+                // Successful Sequential DB Operation.
+                true
             }
-        }.onFailure { throw it }.fold(
-            onSuccess = { emit(true) },
-            onFailure = { it.printLog().also { emit(false) } }
-        )
+        } catch (e: Exception) {
+            e.printLog()
+            false
+        }
     }
 
-    override fun updateBookmark(bookmark: BookmarkVO) = flow {
-        runCatching {
-            localDao.updateBookmark(bookmark.toBookmark())
-        }.onFailure { throw it }.fold(
-            onSuccess = { emit(true) },
-            onFailure = { it.printLog().also { emit(false) } }
-        )
+    override suspend fun updateBookmark(
+        bookmark: BookmarkVO,
+        pending: PendingBookmarkFtsVO?
+    ): Boolean {
+        return try {
+            database.withTransaction {
+                // Update Bookmark Entity
+                localDao.updateBookmark(bookmark.toBookmark())
+                // Insert Pending Entity for Updated Bookmark
+                pending?.let {
+                    localDao.createAsyncFtsEntity(it.toEntry())
+                }
+
+                // Successful Sequential DB Operation
+                true
+            }
+        } catch (e: Exception) {
+            e.printLog()
+            false
+        }
     }
 
     override fun updateNoticeEntity(notice: NoticeVO) = flow {
@@ -88,21 +103,6 @@ class LocalRepositoryImpl @Inject constructor(
         )
     }
 
-    override fun createPendingBookmarkFtsEntity(pendingEntity: PendingBookmarkFtsVO): Flow<Boolean> = flow {
-        runCatching {
-            localDao.createAsyncFtsEntity(
-                PendingBookmarkFtsAsync(
-                    bookmarkId = pendingEntity.bookmarkId,
-                    bookmarkNotes = pendingEntity.notes,
-                    noticeTitle = pendingEntity.title
-                )
-            )
-        }.fold(
-            onSuccess = { emit(true) },
-            onFailure = { it.printLog().also { emit(false) } }
-        )
-    }
-
     override suspend fun queryPendingBookmarkFtsBatched(limit: Int): List<PendingBookmarkFtsVO> {
         runCatching {
             localDao.getPendingBookmarkFtsAsyncBatch(limit)
@@ -110,9 +110,11 @@ class LocalRepositoryImpl @Inject constructor(
             onSuccess = { result ->
                 return result.map {
                     PendingBookmarkFtsVO(
+                        stagingId = it.stagingId,
                         bookmarkId = it.bookmarkId,
                         notes = it.bookmarkNotes,
-                        title = it.noticeTitle
+                        title = it.noticeTitle,
+                        policy = it.stagingPolicy
                     )
                 }
             },
@@ -123,9 +125,9 @@ class LocalRepositoryImpl @Inject constructor(
         return emptyList()
     }
 
-    override fun removePendingBookmarkFtsEntry(bookmarkIds: List<Int>): Flow<Boolean> = flow {
+    override fun removePendingBookmarkFtsEntry(stagingId: List<Int>): Flow<Boolean> = flow {
         runCatching {
-            localDao.removePendingBookmarkFtsAsync(bookmarkIds)
+            localDao.removePendingBookmarkFtsAsync(stagingId)
         }.fold(
             onSuccess = { emit(true) },
             onFailure = { it.printLog().also { emit(false) } }
@@ -190,13 +192,27 @@ class LocalRepositoryImpl @Inject constructor(
         )
     }
 
-    override fun requestBookmarkDeletion(bookmark: BookmarkVO) = flow {
-        runCatching {
-            localDao.deleteBookmark(bookmark.toBookmark())
-        }.onFailure { throw it }.fold(
-            onSuccess = { emit(true) },
-            onFailure = { emit(false) }
-        )
+    override suspend fun requestBookmarkDeletion(
+        bookmark: BookmarkVO,
+        targetNotice: NoticeVO,
+        pending: PendingBookmarkFtsVO
+    ): Boolean {
+        return try {
+            database.withTransaction {
+                // Delete Bookmark first.
+                localDao.deleteBookmark(bookmark.toBookmark())
+                // Delete Notice
+                localDao.deleteNoticeEntity(targetNotice.toNoticeEntity())
+                // Insert Pending Entity for Bookmark Deletion
+                localDao.createAsyncFtsEntity(pending.toEntry())
+
+                // Successful Sequential DB Operation
+                true
+            }
+        } catch (e: Exception) {
+            e.printLog()
+            false
+        }
     }
 
     override fun createBookmarkFts(ftsEntry: BookmarkFtsVO) = flow {
@@ -247,16 +263,6 @@ class LocalRepositoryImpl @Inject constructor(
             onFailure = { emit(false) }
         )
     }
-
-    override fun requestNoticeDeletion(notice: NoticeVO) = flow {
-        runCatching {
-            localDao.deleteNoticeEntity(notice.toNoticeEntity())
-        }.onFailure { throw it }.fold(
-            onSuccess = { emit(true) },
-            onFailure = { emit(false) }
-        )
-    }
-
 
     private fun Throwable.printLog() =
         Log.d(TAG, "Failed to receive data\nREASON: ${this.stackTraceToString()}")
@@ -321,6 +327,14 @@ class LocalRepositoryImpl @Inject constructor(
             isReminderSet = this.isReminderSet,
             createdAt = this.createdAt,
             updatedAt = this.updatedAt
+        )
+
+    private fun PendingBookmarkFtsVO.toEntry() =
+        PendingBookmarkFtsAsync(
+            bookmarkId = this.bookmarkId,
+            bookmarkNotes = this.notes,
+            noticeTitle = this.title,
+            stagingPolicy = this.policy
         )
 
     private fun List<Bookmark>.toListOfBookmarkVO() =

--- a/core/data/src/main/java/com/doyoonkim/data/room/LocalRoomDatabase.kt
+++ b/core/data/src/main/java/com/doyoonkim/data/room/LocalRoomDatabase.kt
@@ -1,8 +1,6 @@
 package com.doyoonkim.data.room
 
 import android.content.Context
-import android.os.Parcel
-import android.os.Parcelable
 import android.util.Log
 import androidx.room.AutoMigration
 import androidx.room.Database
@@ -21,8 +19,8 @@ import kotlinx.coroutines.asExecutor
 
 @Database(
     entities = [Bookmark::class, NoticeEntity::class, BookmarkFts::class, PendingBookmarkFtsAsync::class],
-    version = 4,
-    autoMigrations = [ AutoMigration(from = 2, to = 3), AutoMigration(from = 3, to = 4) ]
+    version = 5,
+    autoMigrations = [ AutoMigration(from = 2, to = 3), AutoMigration(from = 3, to = 4), AutoMigration(from = 4, to = 5) ]
 )
 abstract class LocalDatabase : RoomDatabase() {
     abstract fun getDao(): MainDatabaseDao

--- a/core/data/src/main/java/com/doyoonkim/data/room/MainDatabaseDao.kt
+++ b/core/data/src/main/java/com/doyoonkim/data/room/MainDatabaseDao.kt
@@ -59,9 +59,9 @@ interface MainDatabaseDao {
     fun getPendingBookmarkFtsAsyncBatch(limit: Int): List<PendingBookmarkFtsAsync>
 
     @Query("""
-        DELETE FROM PendingBookmarkFtsAsync WHERE bookmarkId IN (:bookmarkIds)
+        DELETE FROM PendingBookmarkFtsAsync WHERE stagingId IN (:stagingIds)
     """)
-    fun removePendingBookmarkFtsAsync(bookmarkIds: List<Int>)
+    fun removePendingBookmarkFtsAsync(stagingIds: List<Int>)
 
     @Transaction
     fun updateBookmarkFts(

--- a/core/domain/src/main/java/com/doyoonkim/domain/interfaces/BookmarkLocalRepository.kt
+++ b/core/domain/src/main/java/com/doyoonkim/domain/interfaces/BookmarkLocalRepository.kt
@@ -10,11 +10,9 @@ import com.doyoonkim.model.PendingBookmarkFtsVO
 import kotlinx.coroutines.flow.Flow
 
 interface BookmarkLocalRepository {
-    fun createBookmark(bookmark: BookmarkVO): Flow<Boolean>
+    suspend fun createBookmark(bookmark: BookmarkVO, targetNotice: NoticeVO, pending: PendingBookmarkFtsVO): Boolean
 
-    fun createBookmark(bookmark: BookmarkVO, targetNotice: NoticeVO): Flow<Boolean>
-
-    fun updateBookmark(bookmark: BookmarkVO): Flow<Boolean>
+    suspend fun updateBookmark(bookmark: BookmarkVO, pending: PendingBookmarkFtsVO? = null): Boolean
 
     fun queryAllBookmarks(): Flow<List<BookmarkVO>?>
 
@@ -26,7 +24,7 @@ interface BookmarkLocalRepository {
 
     fun queryBookmarkByKeyword(keyword: String, size: Int, pageNumber: Int): Flow<List<BookmarkAsListElementVO>?>
 
-    fun requestBookmarkDeletion(bookmark: BookmarkVO): Flow<Boolean>
+    suspend fun requestBookmarkDeletion(bookmark: BookmarkVO, targetNotice: NoticeVO, pending: PendingBookmarkFtsVO): Boolean
 
     // FTS
     fun createBookmarkFts(ftsEntry: BookmarkFtsVO): Flow<Boolean>
@@ -36,9 +34,7 @@ interface BookmarkLocalRepository {
     fun deleteBookmarkFts(ftsEntry: BookmarkFtsVO): Flow<Boolean>
 
     // Pending FTS Async
-    fun createPendingBookmarkFtsEntity(pendingEntity: PendingBookmarkFtsVO): Flow<Boolean>
-
     suspend fun queryPendingBookmarkFtsBatched(limit: Int): List<PendingBookmarkFtsVO>
 
-    fun removePendingBookmarkFtsEntry(bookmarkIds: List<Int>): Flow<Boolean>
+    fun removePendingBookmarkFtsEntry(stagingId: List<Int>): Flow<Boolean>
 }

--- a/core/domain/src/main/java/com/doyoonkim/domain/interfaces/NoticeLocalRepository.kt
+++ b/core/domain/src/main/java/com/doyoonkim/domain/interfaces/NoticeLocalRepository.kt
@@ -9,6 +9,4 @@ interface NoticeLocalRepository {
 
     fun updateNoticeEntity(notice: NoticeVO): Flow<Boolean>
 
-    fun requestNoticeDeletion(notice: NoticeVO): Flow<Boolean>
-
 }

--- a/core/domain/src/main/java/com/doyoonkim/domain/usecases/InsertPendingFtsEntries.kt
+++ b/core/domain/src/main/java/com/doyoonkim/domain/usecases/InsertPendingFtsEntries.kt
@@ -4,6 +4,7 @@ import com.doyoonkim.domain.interfaces.BookmarkLocalRepository
 import com.doyoonkim.domain.util.KoreanTokenizer
 import com.doyoonkim.model.BookmarkFtsVO
 import com.doyoonkim.model.PendingBookmarkFtsVO
+import com.doyoonkim.model.StagingPolicy
 import com.doyoonkim.model.di.DefaultDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
 import kotlinx.coroutines.async
@@ -20,19 +21,41 @@ class InsertPendingFtsEntriesImpl @Inject constructor(
     @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher
 ): InsertPendingFtsEntries {
     override suspend fun execute(target: PendingBookmarkFtsVO): Boolean {
-        val result = localRepository.createBookmarkFts(
-            BookmarkFtsVO(
-                ftsId = target.bookmarkId,
-                bookmarkNote = target.notes,
-                noticeTitle = target.title,
-                bookmarkNoteTokenized = withContext(defaultDispatcher) {
-                    async { KoreanTokenizer.getTokenizedString(target.notes) }
-                }.await(),
-                noticeTitleTokenized = withContext(defaultDispatcher) {
-                    async { KoreanTokenizer.getTokenizedString(target.title) }
-                }.await()
-            )
-        ).first()
-        return result
+        // Policy Based Execution
+        return when (target.policy) {
+            StagingPolicy.INSERT -> {
+                localRepository.createBookmarkFts(
+                    createFtsVO(target)
+                ).first()
+            }
+            StagingPolicy.UPDATE -> {
+                localRepository.updateBookmarkFts(
+                    createFtsVO(target)
+                ).first()
+            }
+
+            StagingPolicy.DELETE -> {
+                localRepository.deleteBookmarkFts(
+                    createFtsVO(target)
+                ).first()
+            }
+        }
     }
+
+    private suspend fun createFtsVO(target: PendingBookmarkFtsVO): BookmarkFtsVO {
+        return BookmarkFtsVO(
+            ftsId = target.bookmarkId,
+            bookmarkNote = target.notes,
+            noticeTitle = target.title,
+            bookmarkNoteTokenized = tokenization(target.notes),
+            noticeTitleTokenized = tokenization(target.title)
+        )
+    }
+
+    private suspend fun tokenization(target: String): String =
+        withContext(defaultDispatcher) {
+            async {
+                KoreanTokenizer.getTokenizedString(target)
+            }
+        }.await()
 }

--- a/core/domain/src/main/java/com/doyoonkim/domain/usecases/InsertPendingFtsEntries.kt
+++ b/core/domain/src/main/java/com/doyoonkim/domain/usecases/InsertPendingFtsEntries.kt
@@ -56,6 +56,6 @@ class InsertPendingFtsEntriesImpl @Inject constructor(
         withContext(defaultDispatcher) {
             async {
                 KoreanTokenizer.getTokenizedString(target)
-            }
-        }.await()
+            }.await()
+        }
 }

--- a/core/domain/src/main/java/com/doyoonkim/domain/usecases/ModifyBookmark.kt
+++ b/core/domain/src/main/java/com/doyoonkim/domain/usecases/ModifyBookmark.kt
@@ -2,27 +2,19 @@ package com.doyoonkim.domain.usecases
 
 import com.doyoonkim.domain.interfaces.AsyncFtsTaskScheduler
 import com.doyoonkim.domain.interfaces.BookmarkLocalRepository
-import com.doyoonkim.domain.interfaces.NoticeLocalRepository
 import com.doyoonkim.domain.interfaces.NoticeRemoteRepository
-import com.doyoonkim.domain.util.KoreanTokenizer
-import com.doyoonkim.model.BookmarkFtsVO
 import com.doyoonkim.model.BookmarkVO
 import com.doyoonkim.model.NoticeVO
 import com.doyoonkim.model.PendingBookmarkFtsVO
-import com.doyoonkim.model.di.DefaultDispatcher
+import com.doyoonkim.model.StagingPolicy
 import com.doyoonkim.model.di.IoDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
-import kotlinx.coroutines.async
 import kotlinx.coroutines.flow.Flow
 import kotlinx.coroutines.flow.catch
-import kotlinx.coroutines.flow.combine
-import kotlinx.coroutines.flow.emitAll
-import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.firstOrNull
 import kotlinx.coroutines.flow.flow
 import kotlinx.coroutines.flow.flowOn
 import kotlinx.coroutines.flow.transform
-import kotlinx.coroutines.withContext
 import javax.inject.Inject
 
 interface ModifyBookmark {
@@ -35,12 +27,10 @@ interface ModifyBookmark {
 }
 
 class ModifyBookmarkImpl @Inject constructor(
-    private val noticeLocalRepository: NoticeLocalRepository,
     private val bookmarkLocalRepository: BookmarkLocalRepository,
     private val remoteRepository: NoticeRemoteRepository,
     private val pendingWorkScheduler: AsyncFtsTaskScheduler,
-    @IoDispatcher private val ioDispatcher: CoroutineDispatcher,
-    @DefaultDispatcher private val defaultDispatcher: CoroutineDispatcher
+    @IoDispatcher private val ioDispatcher: CoroutineDispatcher
 ) : ModifyBookmark {
 
     override fun query(nttId: Int): Flow<BookmarkVO> =
@@ -51,83 +41,56 @@ class ModifyBookmarkImpl @Inject constructor(
         }.flowOn(ioDispatcher)
 
     override fun createOrUpdate(bookmark: BookmarkVO, notice: NoticeVO?) = flow {
-        println("ModifyBookmarkImpl\t\tCreate: ${notice == null}")
         if (notice == null) {
-            println("ModifyBookmarkImpl\t\tQuery RemoteSource")
+            // Creation
             // Need creation. Request notice instance from the remote source first.
             val vo = remoteRepository.queryNoticeById(bookmark.targetNoticeNttId)
                 .firstOrNull()
-            vo?.let {
-                val bookmarkCreation = bookmarkLocalRepository.createBookmark(bookmark, vo)
-                    .first()
+            if (vo == null) emit(false).also { return@flow }
 
-                if (bookmarkCreation) {
-                    val savedBookmark = bookmarkLocalRepository.queryBookmarkByNttId(vo.nttId)
-                        .firstOrNull()
+            // Bookmark Entity Creation (Sequential DB Operation)
+            val result = bookmarkLocalRepository.createBookmark(
+                bookmark, vo, PendingBookmarkFtsVO(
+                    bookmarkId = bookmark.bookmarkId,
+                    notes = bookmark.bookmarkNote,
+                    title = vo.title,
+                    policy = StagingPolicy.INSERT
+                )
+            )
 
-                    savedBookmark?.let {
-//                        val ftsCreation = bookmarkLocalRepository.createBookmarkFts(
-//                            generateBookmarkFtsEntry(it, vo)
-//                        ).first()
-                        val enqueueResult = bookmarkLocalRepository.createPendingBookmarkFtsEntity(
-                            PendingBookmarkFtsVO(
-                                bookmarkId = it.bookmarkId,
-                                notes = it.bookmarkNote,
-                                title = vo.title
-                            )
-                        ).first()
-                        pendingWorkScheduler.execute()
+            if (result) pendingWorkScheduler.execute()
 
-                        emit(enqueueResult)
-                    } ?: emit(false)
-                } else {
-                    emit(false)
-                }
-            } ?: emit(false)
+            emit(result)
         } else {
-            val updateBookmark = bookmarkLocalRepository.updateBookmark(bookmark)
-                .first()
-            val updateFts = bookmarkLocalRepository.updateBookmarkFts(
-                generateBookmarkFtsEntry(bookmark, notice)
-            ).first()
+            // Update
+            val result = bookmarkLocalRepository.updateBookmark(
+                bookmark, PendingBookmarkFtsVO(
+                    bookmarkId = bookmark.bookmarkId,
+                    notes = bookmark.bookmarkNote,
+                    title = notice.title,
+                    policy = StagingPolicy.UPDATE
+                )
+            )
+            if (result) pendingWorkScheduler.execute()
 
-            emit(updateBookmark && updateFts)
+            emit(result)     // Bookmark Entity insertion is already successful.
         }
     }.catch { /* Internal Error */ }.flowOn(ioDispatcher)
 
-    override fun delete(bookmark: BookmarkVO, notice: NoticeVO): Flow<Boolean> =
-        bookmarkLocalRepository.requestBookmarkDeletion(bookmark).transform { result ->
-            if (result) {
-                emitAll(
-                    combine(
-                        noticeLocalRepository.requestNoticeDeletion(notice),
-                        bookmarkLocalRepository.deleteBookmarkFts(
-                            generateBookmarkFtsEntry(bookmark, notice)
-                        )
-                    ) { first, second ->
-                        first && second
-                    }
-                )
-            }
-            else emit(false)
-        }.catch {
-            /* Internal Error. Consume values, and never emit values. */
-        }.flowOn(ioDispatcher)
+    override fun delete(bookmark: BookmarkVO, notice: NoticeVO): Flow<Boolean> = flow {
+        val result = bookmarkLocalRepository.requestBookmarkDeletion(
+            bookmark, notice, PendingBookmarkFtsVO(
+                bookmarkId = bookmark.bookmarkId,
+                notes = bookmark.bookmarkNote,
+                title = notice.title,
+                policy = StagingPolicy.DELETE
+            ))
+        if (result) pendingWorkScheduler.execute()
 
-
-    private suspend fun generateBookmarkFtsEntry(bookmark: BookmarkVO, notice: NoticeVO): BookmarkFtsVO {
-        return BookmarkFtsVO(
-            ftsId = bookmark.bookmarkId,
-            bookmarkNote = bookmark.bookmarkNote,
-            noticeTitle = notice.title,
-            bookmarkNoteTokenized = withContext(defaultDispatcher) {
-                async { KoreanTokenizer.getTokenizedString(bookmark.bookmarkNote) }
-            }.await(),
-            noticeTitleTokenized = withContext(defaultDispatcher) {
-                async { KoreanTokenizer.getTokenizedString(notice.title) }
-            }.await()
-        )
-    }
+        emit(result)
+    }.catch {
+        /* Internal Error. Consume values, and never emit values. */
+    }.flowOn(ioDispatcher)
 
 }
 

--- a/core/domain/src/main/java/com/doyoonkim/domain/usecases/SyncDataWithUpdatedDatabase.kt
+++ b/core/domain/src/main/java/com/doyoonkim/domain/usecases/SyncDataWithUpdatedDatabase.kt
@@ -101,7 +101,7 @@ class SyncDataWithUpdatedDatabaseImpl @Inject constructor(
                             if (bookmark.updatedAt > 0) bookmark.updatedAt
                             else noticeLocal.timestamp.toLong()
                     ).also { println("Synced Bookmark: ${it.toString()}") }
-                    bookmarkLocalRepository.updateBookmark(syncedBookmark).firstOrNull()
+                    bookmarkLocalRepository.updateBookmark(syncedBookmark)
                 }
 
                 if (!noticeLocal.isSynced()) {

--- a/core/domain/src/main/java/com/doyoonkim/domain/usecases/SyncDataWithUpdatedDatabase.kt
+++ b/core/domain/src/main/java/com/doyoonkim/domain/usecases/SyncDataWithUpdatedDatabase.kt
@@ -101,7 +101,10 @@ class SyncDataWithUpdatedDatabaseImpl @Inject constructor(
                             if (bookmark.updatedAt > 0) bookmark.updatedAt
                             else noticeLocal.timestamp.toLong()
                     ).also { println("Synced Bookmark: ${it.toString()}") }
-                    bookmarkLocalRepository.updateBookmark(syncedBookmark)
+                    if (!bookmarkLocalRepository.updateBookmark(syncedBookmark)) {
+                        failureCounts++
+                        continue
+                    }
                 }
 
                 if (!noticeLocal.isSynced()) {
@@ -118,7 +121,10 @@ class SyncDataWithUpdatedDatabaseImpl @Inject constructor(
                     val syncedNotice = noticeLocal.copy(
                         noticeName = noticeRemote.noticeName
                     ).also { println("Synced Notice: ${it.toString()}") }
-                    noticeLocalRepository.updateNoticeEntity(syncedNotice).firstOrNull()
+                    if (!noticeLocalRepository.updateNoticeEntity(syncedNotice).first()) {
+                        failureCounts++
+                        continue
+                    }
                 }
             } catch (e: Exception) {
                 // Error occurred during synchronization

--- a/core/model/src/main/java/com/doyoonkim/model/PendingBookmarkFtsVO.kt
+++ b/core/model/src/main/java/com/doyoonkim/model/PendingBookmarkFtsVO.kt
@@ -1,7 +1,11 @@
 package com.doyoonkim.model
 
+enum class StagingPolicy { INSERT, UPDATE, DELETE }
+
 data class PendingBookmarkFtsVO(
+    val stagingId: Int = 0,
     val bookmarkId: Int,
     val notes: String,
-    val title: String
+    val title: String,
+    val policy: StagingPolicy
 )


### PR DESCRIPTION
## 📝 Summary (개요)
- Apply robust staging table strategy to all Insert/Update/Delete operation against Bookmark entry to ensure uninterrupted UI during Bookmark Editing.

## 🔗 Related Issue (관련 이슈)
- Resolves _(if applicable)_ #
- Jira Ticket: [KAN-99]

## 🛠 Type of Change (변경 사항)
- [ ] `FEAT`: New feature (새로운 기능)
- [ ] `FIX`: Bug fix (버그 수정)
- [x] `REFACTOR`: Code refactoring (no functional change) (코드 리팩토링)
- [ ] `DESIGN`: UI/UX changes (디자인 변경)
- [ ] `!HOTFIX`: Critical fix (치명적인 버그 수정)
- [ ] `CHORE`: Build/Config/CI (빌드/설정/CI)

## ✨ Key Changes (핵심 변경 사항)
- Staging Table Strategy has been applied to UPDATE/DELETE operation against Bookmark Table (followed by FTS entry modification) (Decrease Loading from 15s > to < 1s)
- Policy-based execution would be applied to determine which operation would be made to actual Indexed FTS table.
- Resolve Identified Core Problem (Atomicity in Sequential DB Operations was not guaranteed). (via Transaction)

## 📸 Screenshots / Video (스크린샷 또는 동영상)
| Before (이전) | After (이후) |
|:---:|:---:|
| <video src="https://github.com/user-attachments/assets/a1c5b2a6-3f3a-480b-a711-2d276232ba75" width="300" /> | <video src="https://github.com/user-attachments/assets/b8bf1a73-6992-426f-baed-bf9aac384d14" width="300" /> |

## 🧪 Test Plan (테스트 계획)
- [x] **Device**: Android Emulator (Pixel 9 Pro, SDK 36)
- [x] **Core**: Database Consistency & Integrity
- [x] **Scenario**: Add new Bookmark -> Modify Bookmark -> Check there's any interrupted UI (exceptionally long Loading state)
- [x] **Scenario**: Delete Bookmark -> Check there's any interrupted UI (exceptionally long loading state) 

## ✅ Checklist (체크리스트)
- [x] My code follows the style guidelines of this project (코드 스타일을 준수했습니다).
- [x] I have performed a self-review of my own code (스스로 코드를 검토했습니다).
- [x] I have commented my code, particularly in hard-to-understand areas (이해하기 어려운 부분에 주석을 작성했습니다).


[KAN-99]: https://knutice.atlassian.net/browse/KAN-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ