### PR TITLE
KAN-99 [FEAT] Implement Pager Indicator

### DIFF
--- a/common/src/main/java/com/doyoonkim/common/ui/HorizontalContentPager.kt
+++ b/common/src/main/java/com/doyoonkim/common/ui/HorizontalContentPager.kt
@@ -45,13 +45,13 @@ private const val MAX_PAGE_MULTIPLIER = 1000
 fun HorizontalContentPager(
     modifier: Modifier = Modifier,
     startingPage: Int,
-    elements: Int,
+    size: Int,
     progressDelay: Long = 5000L,
     pagerContent: @Composable (Int) -> Unit
 ) {
     // Allow user to reverse scroll
     // Prevent potential OutOfBounds due to Process Death. (Potential Size Shrink)
-    val size = elements.coerceAtLeast(1)
+    val size = size.coerceAtLeast(1)
     val maxPage = remember(size) { size * MAX_PAGE_MULTIPLIER }
     val initialPage = startingPage + (maxPage / 2)
 

--- a/common/src/main/java/com/doyoonkim/common/ui/HorizontalContentPager.kt
+++ b/common/src/main/java/com/doyoonkim/common/ui/HorizontalContentPager.kt
@@ -3,6 +3,7 @@ package com.doyoonkim.common.ui
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
+import androidx.compose.foundation.interaction.collectIsDraggedAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.Box
@@ -44,12 +45,13 @@ private const val MAX_PAGE_MULTIPLIER = 1000
 fun HorizontalContentPager(
     modifier: Modifier = Modifier,
     startingPage: Int,
-    size: Int,
+    elements: Int,
     progressDelay: Long = 5000L,
     pagerContent: @Composable (Int) -> Unit
 ) {
     // Allow user to reverse scroll
     // Prevent potential OutOfBounds due to Process Death. (Potential Size Shrink)
+    val size = elements.coerceAtLeast(1)
     val maxPage = remember(size) { size * MAX_PAGE_MULTIPLIER }
     val initialPage = startingPage + (maxPage / 2)
 
@@ -61,10 +63,11 @@ fun HorizontalContentPager(
 
     val pagerInteractionSource = remember { MutableInteractionSource() }
     val isPagePressed by pagerInteractionSource.collectIsPressedAsState()
+    val isPageDragged by pagerInteractionSource.collectIsDraggedAsState()
     val lifecycle = LocalLifecycleOwner.current
 
     // Auto-Advancing
-    if (!isPagePressed && size > 1) {
+    if (!isPagePressed && !isPageDragged && size > 1) {
         LaunchedEffect(pagerState.settledPage, lifecycle) {
             // Prevent potential resource draining when app is in background.
             // Cancel related coroutine when App enters onStop status.

--- a/common/src/main/java/com/doyoonkim/common/ui/HorizontalContentPager.kt
+++ b/common/src/main/java/com/doyoonkim/common/ui/HorizontalContentPager.kt
@@ -1,20 +1,44 @@
 package com.doyoonkim.common.ui
 
-import android.util.Log
+import androidx.compose.foundation.background
+import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
-import androidx.compose.foundation.interaction.collectIsDraggedAsState
-import androidx.compose.foundation.interaction.collectIsHoveredAsState
 import androidx.compose.foundation.interaction.collectIsPressedAsState
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Box
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.Row
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.layout.size
+import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
+import androidx.compose.foundation.layout.wrapContentWidth
 import androidx.compose.foundation.pager.HorizontalPager
 import androidx.compose.foundation.pager.PageSize
 import androidx.compose.foundation.pager.rememberPagerState
+import androidx.compose.foundation.shape.RoundedCornerShape
+import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.LaunchedEffect
 import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
+import androidx.compose.runtime.rememberCoroutineScope
+import androidx.compose.ui.Alignment
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.draw.drawWithCache
+import androidx.compose.ui.geometry.Offset
+import androidx.compose.ui.unit.Dp
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import com.doyoonkim.common.theme.containerGray
+import com.doyoonkim.common.theme.secondaryBackground
+import com.doyoonkim.common.theme.variantPurple
 import kotlinx.coroutines.delay
+import kotlinx.coroutines.launch
+
+private const val MAX_PAGE_MULTIPLIER = 1000
 
 @Composable
 fun HorizontalContentPager(
@@ -25,26 +49,29 @@ fun HorizontalContentPager(
     pagerContent: @Composable (Int) -> Unit
 ) {
     // Allow user to reverse scroll
-    val maxPage = 1000 * size
+    // Prevent potential OutOfBounds due to Process Death. (Potential Size Shrink)
+    val maxPage = remember(size) { size * MAX_PAGE_MULTIPLIER }
     val initialPage = startingPage + (maxPage / 2)
 
     // Pager State
     val pagerState = rememberPagerState(
         initialPage = initialPage,
-        pageCount = { maxPage }
+        pageCount = { maxPage.coerceAtLeast(1) }
     )
 
     val pagerInteractionSource = remember { MutableInteractionSource() }
     val isPagePressed by pagerInteractionSource.collectIsPressedAsState()
+    val lifecycle = LocalLifecycleOwner.current
 
     // Auto-Advancing
     if (!isPagePressed && size > 1) {
-        LaunchedEffect(pagerState, pagerInteractionSource) {
-            while (true) {
+        LaunchedEffect(pagerState.settledPage, lifecycle) {
+            // Prevent potential resource draining when app is in background.
+            // Cancel related coroutine when App enters onStop status.
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 delay(progressDelay)
                 with(pagerState.currentPage) {
                     if (this < maxPage) {
-                        Log.d("HorizontalPager", "Current Statue: ${this}")
                         pagerState.animateScrollToPage(this + 1)
                     }
                 }
@@ -52,13 +79,85 @@ fun HorizontalContentPager(
         }
     }
 
-    HorizontalPager(
-        state = pagerState,
-        modifier = modifier.wrapContentSize(),
-        pageSize = PageSize.Fill,
-        beyondViewportPageCount = 2,
-        userScrollEnabled = true
-    ) { index ->
-        pagerContent(index)
+    Column(
+        modifier = Modifier.wrapContentSize(),
+        horizontalAlignment = Alignment.CenterHorizontally,
+        verticalArrangement = Arrangement.spacedBy(10.dp)
+    ) {
+        HorizontalPager(
+            state = pagerState,
+            modifier = modifier.wrapContentSize(),
+            pageSize = PageSize.Fill,
+            beyondViewportPageCount = 2,
+            userScrollEnabled = true
+        ) { index ->
+            pagerContent(index % size)
+        }
+        HorizontalPagerIndicator(
+            total = size,
+            indicatorSize = 10.dp,
+            selectedProvider = {
+                pagerState.currentPage % size
+            }
+        ) {
+            val diff = it - (pagerState.currentPage % size)
+            with(pagerState) {
+                val target = currentPage + diff
+                if (target in 0..maxPage && !isScrollInProgress) {
+                    animateScrollToPage(target)
+                }
+            }
+        }
+    }
+}
+
+// Indicator
+@Composable
+private fun HorizontalPagerIndicator(
+    total: Int,
+    selectedProvider: () -> Int,
+    indicatorSize: Dp = 20.dp,
+    onIndicatorSelected: suspend (Int) -> Unit
+) {
+    // Local Coroutine Scope
+    val scope = rememberCoroutineScope()
+    Row(
+        modifier = Modifier.wrapContentWidth()
+            .wrapContentHeight()
+            .background(
+                MaterialTheme.colorScheme.secondaryBackground,
+                RoundedCornerShape(20.dp)
+            )
+            .padding(15.dp),
+        verticalAlignment = Alignment.CenterVertically,
+        horizontalArrangement = Arrangement.spacedBy(indicatorSize * 3)
+    ) {
+        // Color
+        val colorSelected = MaterialTheme.colorScheme.variantPurple
+        val colorDefault = MaterialTheme.colorScheme.containerGray
+
+        // Circle Based Indicator
+        repeat(total) {idx ->
+            Box(
+                modifier = Modifier.size(indicatorSize)
+                    .clickable {
+                        scope.launch {
+                            // UI Related Task (rememberCoroutineScope inherits Dispatchers.Main.immediate)
+                            onIndicatorSelected(idx)
+                        }
+                    }
+                    .drawWithCache {
+                        onDrawBehind {
+                            // Color Determination
+                            val color = if (idx == selectedProvider()) colorSelected else colorDefault
+                            drawCircle(
+                                color = color,
+                                radius = size.width / 2f,
+                                center = Offset(size.width / 2f, size.height / 2f)
+                            )
+                        }
+                    }
+            )
+        }
     }
 }


### PR DESCRIPTION
## 📝 Summary (개요)
- Implement Pager Indicator (per request during QA) to HorizontalContentPager in HomeDashbaord.
## 🔗 Related Issue (관련 이슈)
- Resolves _(if applicable)_ #
- Jira Ticket: [KAN-99]

## 🛠 Type of Change (변경 사항)
- [x] `FEAT`: New feature (새로운 기능)
- [ ] `FIX`: Bug fix (버그 수정)
- [x] `REFACTOR`: Code refactoring (no functional change) (코드 리팩토링)
- [x] `DESIGN`: UI/UX changes (디자인 변경)
- [ ] `!HOTFIX`: Critical fix (치명적인 버그 수정)
- [ ] `CHORE`: Build/Config/CI (빌드/설정/CI)

## ✨ Key Changes (핵심 변경 사항)
- Implement Dot-based Pager Indicator to `HorizontalContentPager` in `HomeDashboard` to explicitly indicate user that there's a Horizontal Pager on the Screen.
- Allow Pager Indicator reactively interact with main HorizontalPager content.
- Modify/Enhance Auto-Advancing logic to prevent potential resource draining, especially when app is in background.
- Prevent Auto-advancing process instance advancing after the user-drive scroll event.

## 📸 Screenshots / Video (스크린샷 또는 동영상)
| Before (이전) | After (이후) |
|:---:|:---:|
| <video src="https://github.com/user-attachments/assets/11ca2c7e-30cc-490b-bc5d-bb0f2dc731b2" width="300" /> | <video src="https://github.com/user-attachments/assets/2d44dffc-7432-4ed2-bdca-e4bcef3ae718" width="300" /> |

## 🧪 Test Plan (테스트 계획)
- [x] **Device**: Android Emulator (Pixel 9 Pro, SDK 36)
- [x] **Scenario**: Launch Application -> Swipe HorizontalPager -> Check Pager Indicator correctly reflects the changed page state.
- [x] **Scenario**: Launch Application -> Click pager indicator -> Check Pager correctly animate scroll to the desired page.
- [x] **Scenario**: Launch Application -> Navigate the page (random) -> Place application in background -> Re-enter the application -> Check pager correctly reflects the page state before the application went background. 

## ✅ Checklist (체크리스트)
- [x] My code follows the style guidelines of this project (코드 스타일을 준수했습니다).
- [x] I have performed a self-review of my own code (스스로 코드를 검토했습니다).
- [x] I have commented my code, particularly in hard-to-understand areas (이해하기 어려운 부분에 주석을 작성했습니다).


[KAN-99]: https://knutice.atlassian.net/browse/KAN-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ