### PR TITLE
[FEAT] Implement Local In-Memory Cache Management for Widget Update

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -64,6 +64,8 @@ dependencies {
     implementation(libs.androidx.work.runtime)
     implementation(libs.androidx.work.runtime.ktx)
 
+    implementation(libs.androidx.lifecycle.process)
+
     // Manual Implementation (Heavy Dependency)
     testImplementation(libs.robolectric)
 }

--- a/app/src/main/java/com/doyoonkim/knutice/MainApplication.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/MainApplication.kt
@@ -4,6 +4,7 @@ import android.app.Application
 import android.app.NotificationChannel
 import android.app.NotificationManager
 import android.os.Build
+import androidx.lifecycle.ProcessLifecycleOwner
 import androidx.work.Configuration
 import androidx.work.WorkManager
 import com.doyoonkim.common.di.AppInjector
@@ -51,6 +52,8 @@ class MainApplication() : Application(), AppInjectorProvider, WidgetDependencyPr
         super.onCreate()
         // Application-Level injection
         appComponent.inject(this)
+        // Register Observer on ProcessLifecycleOwner
+        ProcessLifecycleOwner.get().lifecycle.addObserver(widgetSyncObserver)
         configureWorkerManager()
 
         // Create channel group

--- a/app/src/main/java/com/doyoonkim/knutice/WidgetSyncObserver.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/WidgetSyncObserver.kt
@@ -1,0 +1,83 @@
+package com.doyoonkim.knutice
+
+import android.util.Log
+import androidx.lifecycle.DefaultLifecycleObserver
+import androidx.lifecycle.LifecycleOwner
+import com.doyoonkim.common.di.AppPreferences
+import com.doyoonkim.domain.interfaces.LocalWidgetCacheRepository
+import com.doyoonkim.model.WidgetCategoryPolicy
+import com.doyoonkim.widget.model.CarrelWidgetState
+import com.doyoonkim.widget.model.WidgetNoticeVO
+import com.doyoonkim.widget.model.WidgetState
+import com.doyoonkim.widget.util.WidgetStateUpdater
+import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class WidgetSyncObserver @Inject constructor(
+    private val localWidgetCacheRepository: LocalWidgetCacheRepository,
+    private val widgetStateUpdater: WidgetStateUpdater,
+    private val appPreference: AppPreferences,
+    private val applicationScope: CoroutineScope
+): DefaultLifecycleObserver {
+
+    companion object {
+        private const val TAG = "WidgetSyncObserver"
+    }
+
+    override fun onStop(owner: LifecycleOwner) {
+        // Update Widget on App enters its onStop Status.
+        updateNoticeWidgetLocalCache()
+        updateCarrelWidgetLocalCache()
+    }
+
+    private fun updateNoticeWidgetLocalCache() {
+        Log.d(TAG, "Update Notice Widget via Cache")
+        // Check Notice Widget Local Cache
+        val noticeCache = localWidgetCacheRepository.noticeCacheState.value.map { vo ->
+            WidgetNoticeVO(
+                id = vo.nttId,
+                title = vo.title,
+                info = "[${vo.departName}] ${vo.timestamp}",
+                contentUrl = vo.url
+            )
+        }
+        val categoryPolicy = appPreference.getWidgetCategoryPolicy()
+        // Category Mismatch: Recent Category Changed via WidgetConfiguration. Widget is already updated.
+        if (categoryPolicy != localWidgetCacheRepository.widgetCategoryCacheState.value) return
+
+        if (noticeCache.isNotEmpty()) {
+            applicationScope.launch {
+                with(widgetStateUpdater) {
+                    when (categoryPolicy) {
+                        is WidgetCategoryPolicy.Main -> {
+                            updateNoticeWidgetState(
+                                WidgetState(categoryPolicy.categoryKey, noticeCache)
+                            )
+                        }
+                        is WidgetCategoryPolicy.Major -> {
+                            val majorCategory = appPreference.getSubscribedMajor()
+                            majorCategory?.let {
+                                updateNoticeWidgetState(
+                                    WidgetState(it, noticeCache)
+                                )
+                            }
+                        }
+                        else -> { /* DO NOT UPDATE WIDGET */ }
+                    }
+                }
+            }
+        }
+    }
+
+    private fun updateCarrelWidgetLocalCache() {
+        Log.d(TAG, "Update Carrel Widget via Cache")
+        val carrelCache = localWidgetCacheRepository.carrelCacheState.value
+        if (carrelCache.isNotEmpty()) {
+            applicationScope.launch {
+                widgetStateUpdater.updateCarrelWidgetState(CarrelWidgetState(carrelCache))
+            }
+        }
+    }
+
+}

--- a/app/src/main/java/com/doyoonkim/knutice/di/components/SceneComponents.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/di/components/SceneComponents.kt
@@ -3,6 +3,7 @@ package com.doyoonkim.knutice.di.components
 import androidx.lifecycle.ViewModelProvider
 import com.doyoonkim.bookmark.di.BookmarkListSceneModule
 import com.doyoonkim.bookmark.di.EditBookmarkSceneModule
+import com.doyoonkim.data.di.CampusRemoteModule
 import com.doyoonkim.data.di.NoticeRemoteModule
 import com.doyoonkim.data.di.PreferencesRemoteModule
 import com.doyoonkim.data.di.TipRemoteModule
@@ -18,6 +19,7 @@ import com.doyoonkim.knutice.di.util.FirebaseInfrastructureProvider
 import com.doyoonkim.knutice.di.util.LocalStorageProvider
 import com.doyoonkim.knutice.di.util.NetworkProvider
 import com.doyoonkim.knutice.di.util.SystemServices
+import com.doyoonkim.main.di.CarrelStatusSceneModule
 import com.doyoonkim.main.di.CustomerServiceSceneModule
 import com.doyoonkim.main.di.HomeSceneModule
 import com.doyoonkim.main.di.NoticeByMajorSceneModule
@@ -35,6 +37,7 @@ import javax.inject.Singleton
 @Component(
     dependencies = [
         SystemServices::class,
+        LocalStorageProvider::class,
         NetworkProvider::class,
         FirebaseInfrastructureProvider::class
     ],
@@ -55,6 +58,7 @@ interface HomeSceneComponent {
         fun create(
             systemServices: SystemServices,
             networkProvider: NetworkProvider,
+            localStorageProvider: LocalStorageProvider,
             firebaseInfrastructureProvider: FirebaseInfrastructureProvider
         ): HomeSceneComponent
     }
@@ -319,5 +323,30 @@ interface WidgetConfigSceneComponent {
     @Component.Factory
     interface Factory {
         fun create(systemService: SystemServices): WidgetConfigSceneComponent
+    }
+}
+
+@Component(
+    dependencies = [
+        SystemServices::class,
+        NetworkProvider::class,
+        LocalStorageProvider::class
+    ],
+    modules = [
+        ViewModelFactoryModule::class,
+        CarrelStatusSceneModule::class,
+        CampusRemoteModule::class
+    ]
+)
+interface CarrelStatusSceneComponent {
+    fun viewModelFactory(): ViewModelProvider.Factory
+
+    @Component.Factory
+    interface Factory {
+        fun create(
+            systemServices: SystemServices,
+            networkProvider: NetworkProvider,
+            localStorageProvider: LocalStorageProvider
+        ): CarrelStatusSceneComponent
     }
 }

--- a/app/src/main/java/com/doyoonkim/knutice/di/util/DefaultSystemService.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/di/util/DefaultSystemService.kt
@@ -6,8 +6,8 @@ import android.content.Context
 import android.content.SharedPreferences
 import androidx.work.WorkManager
 import com.doyoonkim.common.analytics.AnalyticsLogger
-import com.doyoonkim.common.di.ApplicationScope
 import com.doyoonkim.domain.interfaces.BookmarkLocalRepository
+import com.doyoonkim.domain.interfaces.LocalWidgetCacheRepository
 import com.doyoonkim.domain.interfaces.NoticeLocalRepository
 import com.doyoonkim.model.di.ApplicationContext
 import com.doyoonkim.domain.interfaces.abtest.FirebaseRemoteConfigRepository
@@ -44,6 +44,7 @@ interface NetworkProvider {
 interface LocalStorageProvider {
     fun localNoticeRepository(): NoticeLocalRepository
     fun localBookmarkRepository(): BookmarkLocalRepository
+    fun localWidgetCacheRepository(): LocalWidgetCacheRepository
 }
 
 interface FirebaseInfrastructureProvider {

--- a/app/src/main/java/com/doyoonkim/knutice/navigation/MainServiceNavGraph.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/navigation/MainServiceNavGraph.kt
@@ -63,6 +63,7 @@ fun NavGraphBuilder.mainServiceNavGraph(
             DaggerHomeSceneComponent.factory().create(
                 systemServices = appComponent,
                 networkProvider = appComponent,
+                localStorageProvider = appComponent,
                 firebaseInfrastructureProvider = appComponent
             )
         }

--- a/app/src/main/java/com/doyoonkim/knutice/navigation/campusServiceGraph.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/navigation/campusServiceGraph.kt
@@ -45,7 +45,7 @@ fun NavGraphBuilder.campusServiceGraph(
 
         CarrelStatusScreen(
             modifier = Modifier,
-            appPreferences = appComponent.appPreference()   // Access via Provision function
+            viewModel = viewModel<CarrelStatusViewModel>(factory = sceneComponent.viewModelFactory())
         ) {
             navController.popBackStack()
         }
@@ -78,7 +78,7 @@ fun NavGraphBuilder.campusServiceGraph(
 
         CarrelStatusScreen(
             modifier = Modifier,
-            appPreferences = appComponent.appPreference()   // Access via Provision function
+            viewModel = viewModel<CarrelStatusViewModel>(factory = sceneComponent.viewModelFactory())
         ) {
             navController.popBackStack()
         }

--- a/app/src/main/java/com/doyoonkim/knutice/navigation/campusServiceGraph.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/navigation/campusServiceGraph.kt
@@ -7,13 +7,16 @@ import androidx.compose.animation.core.EaseOut
 import androidx.compose.animation.core.tween
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.viewmodel.compose.viewModel
 import androidx.navigation.NavController
 import androidx.navigation.NavGraphBuilder
 import androidx.navigation.compose.composable
 import com.doyoonkim.common.navigation.NavRoutes
 import com.doyoonkim.knutice.di.components.AppComponent
+import com.doyoonkim.knutice.di.components.DaggerCarrelStatusSceneComponent
 import com.doyoonkim.main.campus.carrel.CarrelStatusScreen
 import com.doyoonkim.main.campus.meal.DiningMenuScreen
+import com.doyoonkim.main.viewmodel.CarrelStatusViewModel
 
 fun NavGraphBuilder.campusServiceGraph(
     navController: NavController,
@@ -36,6 +39,10 @@ fun NavGraphBuilder.campusServiceGraph(
             )
         }
     ) {
+        val sceneComponent = DaggerCarrelStatusSceneComponent.factory().create(
+            appComponent, appComponent, appComponent
+        )
+
         CarrelStatusScreen(
             modifier = Modifier,
             appPreferences = appComponent.appPreference()   // Access via Provision function
@@ -64,6 +71,10 @@ fun NavGraphBuilder.campusServiceGraph(
         val room = backStackEntry.arguments?.getString("roomId")
         val seat = backStackEntry.arguments?.getString("seatNo")
         Log.d("Navigation", "ROOM:$room SEAT: $seat ")
+
+        val sceneComponent = DaggerCarrelStatusSceneComponent.factory().create(
+            appComponent, appComponent, appComponent
+        )
 
         CarrelStatusScreen(
             modifier = Modifier,

--- a/core/data/src/main/java/com/doyoonkim/data/di/LocalModules.kt
+++ b/core/data/src/main/java/com/doyoonkim/data/di/LocalModules.kt
@@ -3,8 +3,10 @@ package com.doyoonkim.data.di
 import android.content.Context
 import com.doyoonkim.model.di.ApplicationContext
 import com.doyoonkim.data.repository.LocalRepositoryImpl
+import com.doyoonkim.data.repository.LocalWidgetCacheRepositoryImpl
 import com.doyoonkim.data.room.LocalDatabase
 import com.doyoonkim.domain.interfaces.BookmarkLocalRepository
+import com.doyoonkim.domain.interfaces.LocalWidgetCacheRepository
 import com.doyoonkim.domain.interfaces.NoticeLocalRepository
 import dagger.Binds
 import dagger.Module
@@ -22,6 +24,12 @@ abstract class LocalModule {
     abstract fun bindsNoticeLocalRepository(
         impl: LocalRepositoryImpl
     ) : NoticeLocalRepository
+
+    @Binds
+    @Singleton
+    abstract fun bindLocalWidgetCacheRepository(
+        impl: LocalWidgetCacheRepositoryImpl
+    ): LocalWidgetCacheRepository
 }
 
 @Module

--- a/core/data/src/main/java/com/doyoonkim/data/di/SystemCoroutineModule.kt
+++ b/core/data/src/main/java/com/doyoonkim/data/di/SystemCoroutineModule.kt
@@ -12,7 +12,7 @@ import javax.inject.Singleton
 object SystemCoroutineModule {
 
     private val applicationScopeCoroutine =
-        CoroutineScope(SupervisorJob() + Dispatchers.Default)
+        CoroutineScope(SupervisorJob() + Dispatchers.IO)
 
     @Provides
     @Singleton

--- a/core/data/src/main/java/com/doyoonkim/data/repository/LocalWidgetCacheRepositoryImpl.kt
+++ b/core/data/src/main/java/com/doyoonkim/data/repository/LocalWidgetCacheRepositoryImpl.kt
@@ -1,0 +1,41 @@
+package com.doyoonkim.data.repository
+
+import android.util.Log
+import com.doyoonkim.common.di.AppPreferences
+import com.doyoonkim.domain.interfaces.LocalWidgetCacheRepository
+import com.doyoonkim.model.CarrelRoomStatusVO
+import com.doyoonkim.model.NoticeVO
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import javax.inject.Inject
+
+class LocalWidgetCacheRepositoryImpl @Inject constructor(
+    appPreference: AppPreferences
+) : LocalWidgetCacheRepository {
+
+    companion object {
+        private const val TAG = "LocalWidgetCacheRepositoryImpl"
+    }
+
+    // StatFlow (Manage In-Memory Cache)
+    private val _noticeCacheState = MutableStateFlow<List<NoticeVO>>(emptyList())
+    override val noticeCacheState = _noticeCacheState.asStateFlow()
+
+    private val _widgetCategoryCacheState = MutableStateFlow(appPreference.getWidgetCategoryPolicy())
+    override val widgetCategoryCacheState = _widgetCategoryCacheState.asStateFlow()
+
+    private val _carrelCacheState = MutableStateFlow<List<CarrelRoomStatusVO>>(emptyList())
+    override val carrelCacheState = _carrelCacheState.asStateFlow()
+
+    override fun updateNoticeCache(notices: List<NoticeVO>) {
+        Log.d(TAG, "Notice Cache Updated")
+        _noticeCacheState.update { notices }
+    }
+
+    override fun updateCarrelCache(status: List<CarrelRoomStatusVO>) {
+        Log.d(TAG, "Carrel Cache Updated")
+        _carrelCacheState.update { status }
+    }
+
+}

--- a/core/domain/src/main/java/com/doyoonkim/domain/interfaces/LocalWidgetCacheRepository.kt
+++ b/core/domain/src/main/java/com/doyoonkim/domain/interfaces/LocalWidgetCacheRepository.kt
@@ -1,0 +1,17 @@
+package com.doyoonkim.domain.interfaces
+
+import com.doyoonkim.model.CarrelRoomStatusVO
+import com.doyoonkim.model.NoticeVO
+import com.doyoonkim.model.WidgetCategoryPolicy
+import kotlinx.coroutines.flow.StateFlow
+
+
+interface LocalWidgetCacheRepository {
+
+    val noticeCacheState: StateFlow<List<NoticeVO>>
+    val widgetCategoryCacheState: StateFlow<WidgetCategoryPolicy>
+    val carrelCacheState: StateFlow<List<CarrelRoomStatusVO>>
+
+    fun updateNoticeCache(notices: List<NoticeVO>)
+    fun updateCarrelCache(status: List<CarrelRoomStatusVO>)
+}

--- a/feature/main/src/main/java/com/doyoonkim/main/campus/carrel/CarrelStatusScreen.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/campus/carrel/CarrelStatusScreen.kt
@@ -11,26 +11,28 @@ import androidx.compose.foundation.layout.systemBars
 import androidx.compose.foundation.layout.windowInsetsPadding
 import androidx.compose.material3.MaterialTheme
 import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.webkit.WebViewCompat
-import com.doyoonkim.common.di.AppPreferences
 import com.doyoonkim.common.theme.displayBackground
 import com.doyoonkim.main.BuildConfig
 import com.doyoonkim.main.campus.components.LifecycleAwareWebView
 import com.doyoonkim.main.campus.model.WebAppAction
 import com.doyoonkim.main.campus.model.WebBridgeEnvelop
+import com.doyoonkim.main.viewmodel.CarrelStatusViewModel
 import kotlinx.serialization.json.Json
 
 @Composable
 fun CarrelStatusScreen(
     modifier: Modifier = Modifier,
-    appPreferences: AppPreferences,
+    viewModel: CarrelStatusViewModel,
     onBackClicked: () -> Unit
 ) {
-    val token = appPreferences.getCachedToken() ?: ""
-    val call = "${BuildConfig.CARREL_BRIDGE}('$token');"
+    val tokenState by viewModel.deviceToken.collectAsStateWithLifecycle()
+    val call = "${BuildConfig.CARREL_BRIDGE}('${tokenState}');"
 
     // Configuration State
     val isKeyProvided = remember { mutableStateOf(false) }

--- a/feature/main/src/main/java/com/doyoonkim/main/di/MainModules.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/di/MainModules.kt
@@ -2,6 +2,7 @@ package com.doyoonkim.main.di
 
 import androidx.lifecycle.ViewModel
 import com.doyoonkim.common.di.ViewModelKey
+import com.doyoonkim.main.viewmodel.CarrelStatusViewModel
 import com.doyoonkim.main.viewmodel.CustomerServiceViewModel
 import com.doyoonkim.main.viewmodel.HomeViewModel
 import com.doyoonkim.main.viewmodel.NoticeByMajorViewModel
@@ -94,4 +95,12 @@ abstract class WidgetConfigSceneModule {
     @IntoMap
     @ViewModelKey(WidgetConfigViewModel::class)
     abstract fun bindsViewModel(viewModel: WidgetConfigViewModel): ViewModel
+}
+
+@Module
+abstract class CarrelStatusSceneModule {
+    @Binds
+    @IntoMap
+    @ViewModelKey(CarrelStatusViewModel::class)
+    abstract fun bindViewModel(viewModel: CarrelStatusViewModel): ViewModel
 }

--- a/feature/main/src/main/java/com/doyoonkim/main/viewmodel/CarrelStatusViewModel.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/viewmodel/CarrelStatusViewModel.kt
@@ -1,0 +1,49 @@
+package com.doyoonkim.main.viewmodel
+
+import android.util.Log
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.viewModelScope
+import com.doyoonkim.common.di.AppPreferences
+import com.doyoonkim.domain.interfaces.CarrelStatusRemoteRepository
+import com.doyoonkim.domain.interfaces.LocalWidgetCacheRepository
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import kotlinx.coroutines.launch
+import javax.inject.Inject
+
+class CarrelStatusViewModel @Inject constructor(
+    private val localWidgetCacheRepository: LocalWidgetCacheRepository,
+    private val carrelStatusRepository: CarrelStatusRemoteRepository,
+    private val appPreference: AppPreferences
+) : ViewModel() {
+
+    // States
+    private val _deviceToken = MutableStateFlow("")
+    val deviceToken = _deviceToken.asStateFlow()
+
+    init {
+        // Hydrate Device Token
+        viewModelScope.launch {
+            _deviceToken.update {
+                appPreference.getCachedToken() ?: ""
+            }
+        }
+        fetchCarrelRoomStateAndUpdateCache()
+    }
+
+    private fun fetchCarrelRoomStateAndUpdateCache() =
+        viewModelScope.launch {
+            carrelStatusRepository.getCarrelRoomStatus()
+                .fold(
+                    onSuccess = {
+                        Log.d("CarrelStatusViewModel", "Fetch Successful")
+                        localWidgetCacheRepository.updateCarrelCache(it)
+                    },
+                    onFailure = {
+                        Log.d("CarrelStatusViewModel", "Unable to fetch status")
+                    }
+                )
+        }
+
+}

--- a/feature/main/src/main/java/com/doyoonkim/main/viewmodel/HomeViewModel.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/viewmodel/HomeViewModel.kt
@@ -7,6 +7,7 @@ import com.doyoonkim.common.analytics.AnalyticsLogger
 import com.doyoonkim.common.base.BaseViewModel
 import com.doyoonkim.common.di.AppPreferences
 import com.doyoonkim.common.navigation.Destination
+import com.doyoonkim.domain.interfaces.LocalWidgetCacheRepository
 import com.doyoonkim.domain.usecases.FetchTips
 import com.doyoonkim.domain.usecases.FetchTopThreeNotices
 import com.doyoonkim.main.contract.HomeEvent
@@ -18,17 +19,33 @@ import com.doyoonkim.main.contract.MajorNoticesState
 import com.doyoonkim.main.contract.TipState
 import com.doyoonkim.model.MajorCategory
 import com.doyoonkim.model.NoticeCategory
+import com.doyoonkim.model.WidgetCategoryPolicy
+import kotlinx.coroutines.async
+import kotlinx.coroutines.coroutineScope
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
 class HomeViewModel @Inject constructor(
+    private val localWidgetCacheRepository: LocalWidgetCacheRepository,
     private val fetchTopThreeNotices: FetchTopThreeNotices,
     private val fetchTips: FetchTips,
     private val appPreferences: AppPreferences,
     private val analytics: AnalyticsLogger
 ) : BaseViewModel<HomeViewState, HomeEvent, HomeSideEffect, HomeMutation>() {
     override fun setInitialState(): HomeViewState = HomeViewState()
+
+    // Local Cache Management
+    init {
+        viewModelScope.launch {
+            uiState.collectLatest { state ->
+                val coreNoticeReady = with(state.mainContentState) { !isLoading && !isError }
+                val majorNoticeReady = with(state.majorNoticesState) { !isLoading && !isError }
+
+                if (coreNoticeReady && majorNoticeReady) updateNoticeLocalCache(state)
+            }
+        }
+    }
 
     override fun handleEvent(event: HomeEvent) {
         when (event) {
@@ -147,6 +164,35 @@ class HomeViewModel @Inject constructor(
                 )
         } ?: mutate(HomeMutation.MajorNotices.Failure("Unable to find subscribed major"))
     }
+
+    private fun updateNoticeLocalCache(snapshot: HomeViewState) =
+        viewModelScope.launch {
+            when (val noticePolicy = appPreferences.getWidgetCategoryPolicy()) {
+                is WidgetCategoryPolicy.Main -> {
+                    localWidgetCacheRepository.updateNoticeCache(
+                        snapshot.mainContentState.get(noticePolicy.categoryKey)
+                    )
+                }
+                is WidgetCategoryPolicy.Major -> {
+                    localWidgetCacheRepository.updateNoticeCache(
+                        snapshot.majorNoticesState.majorNotices
+                    )
+                }
+                else -> {
+                    // Do nothing.
+                }
+            }
+        }
+
+    private fun MainContentState.get(key: String) =
+        when (key) {
+            NoticeCategory.GENERAL_NEWS.name -> this.notificationGeneral
+            NoticeCategory.ACADEMIC_NEWS.name -> this.notificationAcademic
+            NoticeCategory.SCHOLARSHIP_NEWS.name -> this.notificationScholarship
+            NoticeCategory.EVENT_NEWS.name -> this.notificationEvent
+            NoticeCategory.EMPLOYMENT_NEWS.name -> this.notificationEmployment
+            else -> emptyList()
+        }
 
     // Main Reducer
     override fun reduce(currentState: HomeViewState, mutation: HomeMutation): HomeViewState {

--- a/gradle/libs.versions.toml
+++ b/gradle/libs.versions.toml
@@ -2,7 +2,7 @@
 agp = "9.0.0"
 coilCompose = "2.4.0"
 converterGson = "2.11.0"
-datastorePreferences = "1.1.7"
+datastorePreferences = "1.2.0"
 firebaseMessagingDirectboot = "24.0.2"
 jetpackGlance = "1.1.1"
 javaxInject = "1"
@@ -13,6 +13,7 @@ junitVersion = "1.1.5"
 espressoCore = "3.5.1"
 kotlinxCoroutinesAndroid = "1.7.3"
 kotlinxCoroutinesTest = "1.7.3"
+lifecycleProcess = "2.10.0"
 lifecycleRuntimeKtx = "2.9.0"
 activityCompose = "1.10.1"
 composeBom = "2025.05.01"
@@ -50,6 +51,7 @@ androidx-glance-appwidget = { module = "androidx.glance:glance-appwidget", versi
 androidx-glance-appwidget-preview = { module = "androidx.glance:glance-appwidget-preview", version.ref = "jetpackGlance" }
 androidx-glance-material3 = { module = "androidx.glance:glance-material3", version.ref = "jetpackGlance" }
 androidx-glance-preview = { module = "androidx.glance:glance-preview", version.ref = "jetpackGlance" }
+androidx-lifecycle-process = { module = "androidx.lifecycle:lifecycle-process", version.ref = "lifecycleProcess" }
 androidx-material = { module = "androidx.compose.material:material" }
 androidx-navigation-compose = { module = "androidx.navigation:navigation-compose", version.ref = "navigationCompose" }
 androidx-room-compiler = { module = "androidx.room:room-compiler", version.ref = "room" }


### PR DESCRIPTION
## 📝 Summary (개요)
- Implement In-Memory Local Cache to mitigate potential data inconsistency.

## 🔗 Related Issue (관련 이슈)
- Resolves _(if applicable)_ #
- Jira Ticket: [KAN-99]

## 🛠 Type of Change (변경 사항)
- [x] `FEAT`: New feature (새로운 기능)
- [ ] `FIX`: Bug fix (버그 수정)
- [x] `REFACTOR`: Code refactoring (no functional change) (코드 리팩토링)
- [ ] `DESIGN`: UI/UX changes (디자인 변경)
- [ ] `!HOTFIX`: Critical fix (치명적인 버그 수정)
- [x] `CHORE`: Build/Config/CI (빌드/설정/CI)

## ✨ Key Changes (핵심 변경 사항)
- Implement local in-memory cache management to mitigate potential data inconsistency in Widget.
  - Store fetched data from the network to local cache in order to avoid Network-related background work at `onStop` phase of ProcessLifecycle. (Avoid potential background work cancellation by System)
- Define `WidgetSyncObserver` to observe ProcessLifecycle to update widget if necessary, when user close application 

## 📸 Screenshots / Video (스크린샷 또는 동영상)
- Not Applicable

## 🧪 Test Plan (테스트 계획)
- Not Applicable

## ✅ Checklist (체크리스트)
- [x] My code follows the style guidelines of this project (코드 스타일을 준수했습니다).
- [x] I have performed a self-review of my own code (스스로 코드를 검토했습니다).
- [x] I have commented my code, particularly in hard-to-understand areas (이해하기 어려운 부분에 주석을 작성했습니다).


[KAN-99]: https://knutice.atlassian.net/browse/KAN-99?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ