### PR TITLE
[REFACTOR] Resolve UX Issue on saving notice attachments

### DIFF
--- a/common/src/main/res/values-ja/strings.xml
+++ b/common/src/main/res/values-ja/strings.xml
@@ -187,4 +187,5 @@
     <string name="info_ai_summary_not_available">このお知らせはAI要約に対応していません。\n原文をご確認ください。</string>
     <string name="title_dining_menu">学食メニュー</string>
     <string name="info_need_select_major">学科の重要なお知らせを見逃さないように、専攻を設定してみましょう！</string>
+    <string name="text_download_not_available">ファイルをダウンロード 出来ません</string>
 </resources>

--- a/common/src/main/res/values-ko-rKR/strings.xml
+++ b/common/src/main/res/values-ko-rKR/strings.xml
@@ -187,4 +187,5 @@
     <string name="info_ai_summary_not_available">이 공지는 AI 요약이 지원되지 않습니다.\n원문을 확인해 주세요.</string>
     <string name="title_dining_menu">학식 조회</string>
     <string name="info_need_select_major">우리 학과의 중요한 소식을 놓치지 않도록\n전공을 설정해 볼까요?</string>
+    <string name="text_download_not_available">현재 파일을 다운로드 할 수 없어요</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -201,4 +201,5 @@
     <string name="info_ai_summary_not_available">AI summary is unavailable for this notice.\nPlease refer to the original text</string>
     <string name="title_dining_menu">Dining</string>
     <string name="info_need_select_major">Set up your major to start receiving your college\'s announcements!</string>
+    <string name="text_download_not_available">Cannot download attachment.</string>
 </resources>

--- a/feature/main/src/main/java/com/doyoonkim/main/contract/NoticeDetailContract.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/contract/NoticeDetailContract.kt
@@ -32,7 +32,7 @@ sealed interface NoticeDetailEvent: UiEvent {
     data class UpdateLoadingStatus(val status: Int): NoticeDetailEvent
     data object RequestBookmarkCreation: NoticeDetailEvent
     data object RequestNoticeSummary: NoticeDetailEvent
-    data object RequestDownloadAttachment: NoticeDetailEvent
+    data class RequestDownloadAttachment(val status: Boolean): NoticeDetailEvent
     data object DismissBottomSheet: NoticeDetailEvent
     data object GoBack: NoticeDetailEvent
 
@@ -44,6 +44,7 @@ sealed class NoticeDetailSideEffect: UiSideEffect {
     data class NavToEditBookmark(val target: NoticeVO): NoticeDetailSideEffect()
     data object NavToBack: NoticeDetailSideEffect()
     data object ShowDownloadToast: NoticeDetailSideEffect()
+    data object ShowDownloadUnableToast: NoticeDetailSideEffect()
     data object NavToDownload: NoticeDetailSideEffect()
 }
 

--- a/feature/main/src/main/java/com/doyoonkim/main/notice/NoticeDetailScreen.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/notice/NoticeDetailScreen.kt
@@ -171,9 +171,8 @@ fun NoticeDetailScreen(
                 addRequestHeader("User-Agent", userAgent)
                 setDescription("Downloading File")
                 setTitle(filename)
-                //                                      allowScanningByMediaScanner()     Deprecated.
                 setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-                setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, filename)
+                setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, "KNUTICE/$filename")
             }
             val downloadManager = context.getSystemService(DOWNLOAD_SERVICE) as DownloadManager
             downloadManager.enqueue(request).also {

--- a/feature/main/src/main/java/com/doyoonkim/main/notice/NoticeDetailScreen.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/notice/NoticeDetailScreen.kt
@@ -8,6 +8,7 @@ import android.util.Log
 import android.view.View
 import android.webkit.CookieManager
 import android.webkit.DownloadListener
+import android.webkit.MimeTypeMap
 import android.webkit.URLUtil
 import android.webkit.WebChromeClient
 import android.webkit.WebSettings
@@ -71,6 +72,9 @@ import com.doyoonkim.common.ui.markdown.MarkdownView
 import com.doyoonkim.main.campus.components.LifecycleAwareWebView
 import com.doyoonkim.main.contract.NoticeDetailEvent
 import com.doyoonkim.main.contract.NoticeDetailSideEffect
+import java.io.File
+import java.net.URLDecoder
+import java.util.Locale
 
 @OptIn(ExperimentalMaterial3Api::class)
 @Composable
@@ -99,6 +103,9 @@ fun NoticeDetailScreen(
                 is NoticeDetailSideEffect.NavToEditBookmark -> onBookmarkCreate(effect.target)
                 is NoticeDetailSideEffect.ShowDownloadToast -> {
                     Toast.makeText(context, R.string.text_download, Toast.LENGTH_LONG).show()
+                }
+                is NoticeDetailSideEffect.ShowDownloadUnableToast -> {
+                    Toast.makeText(context, R.string.text_download_not_available, Toast.LENGTH_LONG).show()
                 }
                 is NoticeDetailSideEffect.NavToDownload -> {
                     // Guide user to the File application
@@ -160,24 +167,59 @@ fun NoticeDetailScreen(
     val downloadListener = remember {
         DownloadListener { url, userAgent, contentDisposition, mimetype, contentLength ->
             val request = DownloadManager.Request(url.toUri())
-            val filename = URLUtil.guessFileName(url, contentDisposition, mimetype)
-                .also { Log.d("DownloadManager", "Filename: $it") }
+
+            // URL (UTF-8) Encoded Raw Filename
+            val rawFilename = URLUtil.guessFileName(url, contentDisposition, mimetype)
+            val decodedFilename = try {
+                URLDecoder.decode(rawFilename, "UTF-8")
+            } catch (e: Exception) {
+                Log.d("DownloadListener", "Unable to decode the raw filename")
+                rawFilename
+            }.run {
+                // Clean filename
+                File(this).name
+            }
+
+            // Explicitly provide mimetype to process implicit intent via Notification correctly.
+            val fileExtension = MimeTypeMap.getFileExtensionFromUrl(url)
+                ?: decodedFilename.substringAfterLast(".", "")
+            var resolvedMimeType = MimeTypeMap.getSingleton().getMimeTypeFromExtension(
+                fileExtension.lowercase(Locale.ROOT)
+            ) ?: mimetype
+
+            // Process specific file extension (HWP)
+            if (decodedFilename.endsWith(".hwp", ignoreCase = true)) {
+                // override resolve Mime Type via MimeTypeMap.
+                resolvedMimeType = "application/x-hwp"
+            }
+
             // save session data before downloading the target file.
             val cookies = CookieManager.getInstance().getCookie(url)
 
+            Log.d("NoticeDetailScreen", "Processed Filename: $decodedFilename")
             request.apply {
-                setMimeType(mimetype)
+                setMimeType(resolvedMimeType)
                 addRequestHeader("cookie", cookies)
                 addRequestHeader("User-Agent", userAgent)
                 setDescription("Downloading File")
-                setTitle(filename)
+                setTitle(decodedFilename)
                 setNotificationVisibility(DownloadManager.Request.VISIBILITY_VISIBLE_NOTIFY_COMPLETED)
-                setDestinationInExternalPublicDir(Environment.DIRECTORY_DOWNLOADS, "KNUTICE/$filename")
+                setDestinationInExternalPublicDir(
+                    Environment.DIRECTORY_DOWNLOADS,
+                    decodedFilename
+                )
             }
-            val downloadManager = context.getSystemService(DOWNLOAD_SERVICE) as DownloadManager
-            downloadManager.enqueue(request).also {
-                // Guide user to the File application
-                viewModel.sendUiEvent(NoticeDetailEvent.RequestDownloadAttachment)
+
+            // Potential Error Handling
+            try {
+                val downloadManager = context.getSystemService(DOWNLOAD_SERVICE) as DownloadManager
+                downloadManager.enqueue(request).also {
+                    // Guide user to the File application
+                    viewModel.sendUiEvent(NoticeDetailEvent.RequestDownloadAttachment(true))
+                }
+            } catch (e: Exception) {
+                // Potential Error: Download Manager is disabled
+                viewModel.sendUiEvent(NoticeDetailEvent.RequestDownloadAttachment(false))
             }
         }
     }

--- a/feature/main/src/main/java/com/doyoonkim/main/viewmodel/NoticeDetailViewModel.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/viewmodel/NoticeDetailViewModel.kt
@@ -86,6 +86,13 @@ class NoticeDetailViewModel @Inject constructor(
                 mutate(NoticeDetailMutation.Summary.Dismiss)
             }
             is NoticeDetailEvent.RequestDownloadAttachment -> {
+                if (!event.status) {
+                    // Exception Occurred.
+                    sendSideEffect(NoticeDetailSideEffect.ShowDownloadUnableToast)
+                    return
+                }
+
+                // Download Successfully enqueued
                 sendSideEffect(NoticeDetailSideEffect.ShowDownloadToast)
                 sendSideEffect(NoticeDetailSideEffect.NavToDownload)
             }


### PR DESCRIPTION
## 📝 Summary (개요)
- Resolve identified UX issue on saving notice attachments. (Saving/Fetching delay)
## 🔗 Related Issue (관련 이슈)
- Resolves _(if applicable)_ #
- Jira Ticket: [KAN-109]

## 🛠 Type of Change (변경 사항)
- [ ] `FEAT`: New feature (새로운 기능)
- [ ] `FIX`: Bug fix (버그 수정)
- [x] `REFACTOR`: Code refactoring (no functional change) (코드 리팩토링)
- [ ] `DESIGN`: UI/UX changes (디자인 변경)
- [ ] `!HOTFIX`: Critical fix (치명적인 버그 수정)
- [ ] `CHORE`: Build/Config/CI (빌드/설정/CI)

## ✨ Key Changes (핵심 변경 사항)
- (`OUTDATED`) Provide explicit, isolated folder for attachments downloaded via KNUTICE application. Destination Path would be: Downloads/KNUTICE/...
- Identify fundamental reason for the issue: Incorrectly processed filename (UTF-8 encoded), and mime type, especially `.hwp` extension.
- Modify and improve `DownloadListener` logic to process encoded filename correctly, and aggressively resolve target file's mime type.  

## 📸 Screenshots / Video (스크린샷 또는 동영상)
| Before (이전) | After (이후) |
|:---:|:---:|
| <video src="https://github.com/user-attachments/assets/65c5c11a-b120-43af-8ec9-34125a4e3ea7" width="300" /> | <video src="https://github.com/user-attachments/assets/8a2fe942-bceb-4656-a8ad-9971d6973439" width="300" /> |

## 🧪 Test Plan (테스트 계획)
- [x] **Device**: Samsung Remote Testing Device (Galaxy S26, SDK 36)
- [x] **Scenario**: Download Notice Attachment, in .pdf format, with Korean filename -> Check file is instantly visible under `Donwloads` folder, without broken filename -> Check file is opened via associated applicaiton.
- [x] **Scenario**: Download Notice Attachment, in .hwp format, with Korean filename -> Check file is instantly visible in `Downloads` folder, without broken filename. -> Check file is opened via associated application.

## ✅ Checklist (체크리스트)
- [x] My code follows the style guidelines of this project (코드 스타일을 준수했습니다).
- [x] I have performed a self-review of my own code (스스로 코드를 검토했습니다).
- [x] I have commented my code, particularly in hard-to-understand areas (이해하기 어려운 부분에 주석을 작성했습니다).


[KAN-109]: https://knutice.atlassian.net/browse/KAN-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ