### PR TITLE
[REFACTOR] Tip Container Visibility and Design Fix

### DIFF
--- a/common/src/main/java/com/doyoonkim/common/ui/TipContainer.kt
+++ b/common/src/main/java/com/doyoonkim/common/ui/TipContainer.kt
@@ -36,34 +36,10 @@ fun TipContainer(
     }
 
     Row(
-        modifier = modifier.wrapContentHeight()
-            .padding(
-                horizontal = 10.dp,
-                vertical = 7.dp
-            ),
+        modifier = modifier.padding(horizontal = 10.dp, vertical = 7.dp),
         verticalAlignment = Alignment.CenterVertically,
         horizontalArrangement = Arrangement.spacedBy(4.dp)
     ) {
-/*
-        Surface(
-            modifier = Modifier.wrapContentSize()
-                .background(Color.Transparent),
-            color = MaterialTheme.colorScheme.containerGray,
-            shape = RoundedCornerShape(15.dp)
-        ) {
-            Text(
-                modifier = Modifier.wrapContentSize().padding(
-                    vertical = 5.dp,
-                    horizontal = 10.dp
-                ),
-                text = tagTitle,
-                fontSize = 14.sp,
-                fontWeight = FontWeight.Bold,
-                textAlign = TextAlign.Center,
-                color = MaterialTheme.colorScheme.title
-            )
-        }
- */
         Text(
             modifier = Modifier.wrapContentSize(),
             text = tipText,

--- a/common/src/main/java/com/doyoonkim/common/ui/TipPager.kt
+++ b/common/src/main/java/com/doyoonkim/common/ui/TipPager.kt
@@ -1,14 +1,12 @@
 package com.doyoonkim.common.ui
 
-import android.util.Log
 import androidx.compose.foundation.background
 import androidx.compose.foundation.clickable
 import androidx.compose.foundation.interaction.MutableInteractionSource
 import androidx.compose.foundation.interaction.collectIsPressedAsState
-import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
-import androidx.compose.foundation.layout.wrapContentHeight
+import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.pager.PageSize
 import androidx.compose.foundation.pager.VerticalPager
 import androidx.compose.foundation.pager.rememberPagerState
@@ -21,19 +19,19 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.graphics.Color
-import androidx.compose.ui.graphics.graphicsLayer
-import androidx.compose.ui.tooling.preview.Preview
 import androidx.compose.ui.unit.dp
-import androidx.compose.ui.util.lerp
-import com.doyoonkim.common.theme.onAnyBackground
+import androidx.lifecycle.Lifecycle
+import androidx.lifecycle.compose.LocalLifecycleOwner
+import androidx.lifecycle.repeatOnLifecycle
+import com.doyoonkim.common.theme.secondaryBackground
 import com.doyoonkim.model.TipVO
 import kotlinx.coroutines.delay
-import kotlin.math.absoluteValue
 
 @Composable
 fun TipPager(
     modifier: Modifier,
     tips: List<TipVO> = emptyList(),
+    isLoading: Boolean = false,
     onTipClicked: (String) -> Unit
 ) {
     // Pager State
@@ -41,12 +39,15 @@ fun TipPager(
 
     val pageInteractionSource = remember { MutableInteractionSource() }
     val isPagePressed by pageInteractionSource.collectIsPressedAsState()
+    val lifecycle = LocalLifecycleOwner.current
 
     // Auto-Advancing
     val isAutoAdvancing = !isPagePressed && tips.size > 1
     if (isAutoAdvancing) {
-        LaunchedEffect(pagerState, pageInteractionSource) {
-            while (true) {
+        LaunchedEffect(pagerState.settledPage, lifecycle ) {
+            // Prevent potential resource draining under Auto-Advancing implementation
+            // when app is in background.
+            lifecycle.repeatOnLifecycle(Lifecycle.State.STARTED) {
                 delay(5000L)
                 with(pagerState.currentPage) {
                     if (this < Int.MAX_VALUE) {
@@ -57,49 +58,41 @@ fun TipPager(
         }
     }
 
-    Surface(
-        modifier = Modifier.fillMaxSize()
-            .wrapContentHeight()
-            .background(Color.Transparent)
-            .clickable {
-                onTipClicked(
-                    tips[pagerState.currentPage % tips.size].url
+    // Either loading or tip is not empty, Pager becomes visible.
+    // Loading -> Placeholder (Skeleton Animation)
+    // Tip is not empty -> Show tips.
+    if (isLoading || tips.isNotEmpty()) {
+        Surface(
+            modifier = modifier
+                .background(Color.Transparent)
+                .clickable {
+                    onTipClicked(
+                        tips[pagerState.currentPage % tips.size].url
+                    )
+                },
+            color = MaterialTheme.colorScheme.secondaryBackground,
+            shape = RoundedCornerShape(15.dp)
+        ) {
+            if (isLoading) {
+                AnimatedGradient(
+                    modifier = Modifier.height(30.dp)
+                        .padding(horizontal = 15.dp, vertical = 8.dp)
                 )
-            },
-        color = MaterialTheme.colorScheme.onAnyBackground,
-        shape = RoundedCornerShape(15.dp)
-    ) {
-        // Vertical Pager
-        VerticalPager(
-            modifier = modifier,
-            pageSize = PageSize.Fixed(50.dp),
-            userScrollEnabled = false,
-            state = pagerState
-        ) { index ->
-            Log.d("TipPager", "Current Page: $index State Status: ${pagerState.currentPage}")
-            Log.d("TipPager", "INDEX?: ${index % pagerState.pageCount}")
-            TipContainer(
-                modifier = Modifier.fillMaxWidth().height(50.dp)
-                    .graphicsLayer {
-                        val pageOffset = (
-                                (pagerState.currentPage - index) + pagerState.currentPageOffsetFraction
-                                ).absoluteValue
-
-                        alpha = lerp(
-                            start = 0.5f,
-                            stop = 1f,
-                            fraction = 1f - pageOffset.coerceIn(0f, 1f)
-                        )
-                    },
-                tipCategory = TipCategory.UPDATES,
-                tipText = tips[index % tips.size].title
-            )
+            } else {
+                // Vertical Pager
+                VerticalPager(
+                    modifier = Modifier.height(50.dp),
+                    pageSize = PageSize.Fill,
+                    userScrollEnabled = false,
+                    state = pagerState
+                ) { index ->
+                    TipContainer(
+                        modifier = Modifier.fillMaxWidth().height(50.dp),
+                        tipCategory = TipCategory.UPDATES,
+                        tipText = tips[index % tips.size].title
+                    )
+                }
+            }
         }
     }
-}
-
-@Composable
-@Preview(showBackground = true)
-fun TipPager_Preview() {
-
 }

--- a/common/src/main/java/com/doyoonkim/common/ui/TipPager.kt
+++ b/common/src/main/java/com/doyoonkim/common/ui/TipPager.kt
@@ -65,7 +65,9 @@ fun TipPager(
         Surface(
             modifier = modifier
                 .background(Color.Transparent)
-                .clickable {
+                .clickable(
+                    enabled = !isLoading && tips.isNotEmpty()
+                ) {
                     onTipClicked(
                         tips[pagerState.currentPage % tips.size].url
                     )

--- a/feature/main/src/main/java/com/doyoonkim/main/home/HomeDashboard.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/home/HomeDashboard.kt
@@ -1,13 +1,11 @@
 package com.doyoonkim.main.home
 
-import android.util.Log
 import androidx.activity.compose.BackHandler
 import androidx.compose.foundation.Image
 import androidx.compose.foundation.background
 import androidx.compose.foundation.layout.Arrangement
 import androidx.compose.foundation.layout.PaddingValues
 import androidx.compose.foundation.layout.Row
-import androidx.compose.foundation.layout.Spacer
 import androidx.compose.foundation.layout.fillMaxSize
 import androidx.compose.foundation.layout.fillMaxWidth
 import androidx.compose.foundation.layout.height
@@ -15,6 +13,7 @@ import androidx.compose.foundation.layout.padding
 import androidx.compose.foundation.layout.wrapContentHeight
 import androidx.compose.foundation.layout.wrapContentSize
 import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.rememberLazyListState
 import androidx.compose.foundation.shape.RoundedCornerShape
 import androidx.compose.material3.Button
 import androidx.compose.material3.ButtonDefaults
@@ -44,7 +43,6 @@ import com.doyoonkim.common.navigation.Destination
 import com.doyoonkim.common.theme.buttonOnBackground
 import com.doyoonkim.common.theme.displayBackground
 import com.doyoonkim.common.theme.secondaryBackground
-import com.doyoonkim.common.theme.subTitle
 import com.doyoonkim.common.theme.title
 import com.doyoonkim.common.ui.DashboardPlaceholder
 import com.doyoonkim.common.ui.EntryPointButton
@@ -158,27 +156,31 @@ fun HomeDashboard(
         } else {
             // Read HomeScreen content safe bottom padding
             val bottomPadding = LocalHomeSafeBottomPadding.current
-            Log.d("HomeScreen", "Safe Padding: $bottomPadding")
+            
+            // LazyColumnState
+            val lazyColumnState = rememberLazyListState()
+
             LazyColumn(
                 modifier = modifier
                     .padding(innerPadding)
                     .background(MaterialTheme.colorScheme.displayBackground),
+                state = lazyColumnState,
                 horizontalAlignment = Alignment.CenterHorizontally,
                 verticalArrangement = Arrangement.spacedBy(20.dp),
                 contentPadding = PaddingValues(bottom = bottomPadding)
             ) {
-                if (!uiState.tipState.isError && uiState.tipState.tips.isNotEmpty()) {
+                if (!uiState.tipState.isError) {
                     item("tip") {
                         TipPager(
                             modifier = Modifier
                                 .fillMaxWidth()
                                 .height(50.dp)
-                                .padding(5.dp),
-                            tips = uiState.tipState.tips
+                                .padding(horizontal = 7.dp),
+                            tips = uiState.tipState.tips,
+                            isLoading = uiState.tipState.isLoading
                         ) {
                             viewModel.sendUiEvent(HomeEvent.RequestTipDetail(TipCategory.UPDATES, it))
                         }
-                        Spacer(Modifier.height(15.dp))
                     }
                 }
 


### PR DESCRIPTION
## 📝 Summary (개요)
- Enhance Tip Container visibility and Design on HomeDashboard screen for better UX and easy access to the Tip Contents.
## 🔗 Related Issue (관련 이슈)
- Resolves _(if applicable)_ #
- Jira Ticket: [KAN-110]

## 🛠 Type of Change (변경 사항)
- [ ] `FEAT`: New feature (새로운 기능)
- [x] `FIX`: Bug fix (버그 수정)
- [x] `REFACTOR`: Code refactoring (no functional change) (코드 리팩토링)
- [x] `DESIGN`: UI/UX changes (디자인 변경)
- [ ] `!HOTFIX`: Critical fix (치명적인 버그 수정)
- [ ] `CHORE`: Build/Config/CI (빌드/설정/CI)

## ✨ Key Changes (핵심 변경 사항)
- Enable Skeleton Loading Animation to TipContainer to ensure fixed area of the Tip Container on HomeDashboard Screen until the fetching result is available.
- Minor Design Fix to ensure overall theme consistency.
- Remove unnecessary code (TipContainer Composable)

## 📸 Screenshots / Video (스크린샷 또는 동영상)
| Before (이전) | After (이후) |
|:---:|:---:|
| <video src="https://github.com/user-attachments/assets/3e7b320f-5b20-423a-a2f5-c30247f97b3e" width="300" /> | <video src="https://github.com/user-attachments/assets/a1e8d658-c82c-47e2-aaac-e8907efb313f" width="300" /> |

## 🧪 Test Plan (테스트 계획)
- [x] **Device**: Android Emulator (Google Pixel 9 Pro, SDK 36)
- [x] **Scenario**: Launch Application (Simulate Successful Fetching by setting Fetching Category as `AOS`) -> Check Tip Container visibility during loading with Skeleton Animation -> Check Tip Container visibility after successful tip fetching.
- [x] **Scenario**: Launch Application (Simulate Fetching Failure by setting Fetching Category as `UNKNOWN`) -> Check Tip Container visibility during loading with Skeleton Animation -> Check Tip Container gets disappeared after receiving fetch failure result

## ✅ Checklist (체크리스트)
- [x] My code follows the style guidelines of this project (코드 스타일을 준수했습니다).
- [x] I have performed a self-review of my own code (스스로 코드를 검토했습니다).
- [x] I have commented my code, particularly in hard-to-understand areas (이해하기 어려운 부분에 주석을 작성했습니다).


[KAN-110]: https://knutice.atlassian.net/browse/KAN-110?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ