### PR TITLE
[!HOTFIX] Fatal Issue Mitigation

### DIFF
--- a/app/build.gradle.kts
+++ b/app/build.gradle.kts
@@ -15,7 +15,7 @@ configure<ApplicationExtension>() {
 
     defaultConfig {
         applicationId = "com.doyoonkim.knutice"
-        versionCode = 40
+        versionCode = 41
         versionName = "@string/version_code"
     }
     buildTypes {

--- a/common/src/main/res/values-ja/strings.xml
+++ b/common/src/main/res/values-ja/strings.xml
@@ -188,4 +188,5 @@
     <string name="title_dining_menu">学食メニュー</string>
     <string name="info_need_select_major">学科の重要なお知らせを見逃さないように、専攻を設定してみましょう！</string>
     <string name="text_download_not_available">ファイルをダウンロード 出来ません</string>
+    <string name="text_content_unavailable">ページを読み込めません。</string>
 </resources>

--- a/common/src/main/res/values-ko-rKR/strings.xml
+++ b/common/src/main/res/values-ko-rKR/strings.xml
@@ -188,4 +188,5 @@
     <string name="title_dining_menu">학식 조회</string>
     <string name="info_need_select_major">우리 학과의 중요한 소식을 놓치지 않도록\n전공을 설정해 볼까요?</string>
     <string name="text_download_not_available">현재 파일을 다운로드 할 수 없어요</string>
+    <string name="text_content_unavailable">화면을 불러오는 데 문제가 생겼어요.</string>
 </resources>

--- a/common/src/main/res/values/strings.xml
+++ b/common/src/main/res/values/strings.xml
@@ -12,7 +12,7 @@
     <string name="about_title">About</string>
     <string name="about_version">Version</string>
     <string name="about_oss">Open Source License</string>
-    <string name="version_code" translatable="false">1.7.1</string>
+    <string name="version_code" translatable="false">1.7.2</string>
     <string name="pref_notification_title">Notification</string>
     <string name="title_preference">Preference</string>
     <string name="new_notice">New Notice has been delivered!</string>
@@ -202,4 +202,5 @@
     <string name="title_dining_menu">Dining</string>
     <string name="info_need_select_major">Set up your major to start receiving your college\'s announcements!</string>
     <string name="text_download_not_available">Cannot download attachment.</string>
+    <string name="text_content_unavailable">We are having trouble loading this page.</string>
 </resources>

--- a/core/notification/src/main/java/com/doyoonkim/notification/fcm/TokenHandler.kt
+++ b/core/notification/src/main/java/com/doyoonkim/notification/fcm/TokenHandler.kt
@@ -19,8 +19,13 @@ class TokenHandlerImpl @Inject constructor(
     private val TAG = this.javaClass.name
 
     override suspend fun invoke(t: String?): TokenStatus {
-        val token = t ?: Firebase.messaging.token.await()
+        val token = t ?: getToken()
         val cached = appPreferences.getCachedToken()
+
+        if (token == null)  {
+            // Firebase Service Unavailable
+            return TokenStatus.RETRY
+        }
 
         if (token != cached) appPreferences.updateDeviceToken(token)
 
@@ -49,12 +54,25 @@ class TokenHandlerImpl @Inject constructor(
         )
 
     override suspend fun validation(): Boolean {
-        val token = Firebase.messaging.token.await()
+        val token = getToken()
         val cached = appPreferences.getCachedToken()
 
         Log.d(TAG, "Received: $token")
         Log.d(TAG, "Cached: $cached")
 
+        if (token == null) return false
+
         return token == cached
+    }
+
+    // Access Token with Exception Handling
+    private suspend fun getToken(): String? {
+        return try {
+            Firebase.messaging.token.await()
+        } catch (e: Exception) {
+            // Unable to access to Token (IPC Failure; Firebase Service Not Available.)
+            Log.e("TokenHandler", "Unable to access Token ${e.localizedMessage}")
+            null
+        }
     }
 }

--- a/core/notification/src/main/java/com/doyoonkim/notification/fcm/TokenHandler.kt
+++ b/core/notification/src/main/java/com/doyoonkim/notification/fcm/TokenHandler.kt
@@ -9,6 +9,7 @@ import com.doyoonkim.model.requestBody.DeviceTokenBody
 import com.doyoonkim.model.requestBody.TokenUpdateBody
 import com.google.firebase.Firebase
 import com.google.firebase.messaging.messaging
+import kotlinx.coroutines.CancellationException
 import kotlinx.coroutines.tasks.await
 import javax.inject.Inject
 
@@ -70,8 +71,11 @@ class TokenHandlerImpl @Inject constructor(
         return try {
             Firebase.messaging.token.await()
         } catch (e: Exception) {
+            // Throw Cancellation Exception to ensure structured concurrency.
+            if (e is CancellationException) throw e
+
             // Unable to access to Token (IPC Failure; Firebase Service Not Available.)
-            Log.e("TokenHandler", "Unable to access Token ${e.localizedMessage}")
+            Log.e(TAG, "Unable to access Token")
             null
         }
     }

--- a/feature/main/src/main/java/com/doyoonkim/main/campus/components/LifecycleAwareAndroidView.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/campus/components/LifecycleAwareAndroidView.kt
@@ -1,7 +1,11 @@
 package com.doyoonkim.main.campus.components
 
 import android.annotation.SuppressLint
+import android.app.Activity
+import android.content.Context
+import android.content.ContextWrapper
 import android.graphics.Color
+import android.util.Log
 import android.view.View
 import android.view.ViewGroup
 import android.webkit.WebSettings
@@ -14,10 +18,22 @@ import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.platform.LocalContext
+import androidx.compose.ui.res.stringResource
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
+import com.doyoonkim.common.ui.PlaceholderScreen
+import com.doyoonkim.common.R
+
+// App-Level Issue
+// Context Helper. Mitigate potential issue caused by Injected Context via Dagger.
+private fun Context.findActivity(): Activity? = when(this) {
+    is Activity -> this
+    is ContextWrapper -> baseContext.findActivity()
+    else -> null
+}
 
 @Composable
 fun LifecycleAwareWebView(
@@ -30,6 +46,13 @@ fun LifecycleAwareWebView(
 ) {
     var webViewInstance by remember { mutableStateOf<WebView?>(null) }
     var lastLoadedUrl by remember { mutableStateOf("") }
+
+    // OS-level Resource Failure: When WebViewEngine is not available (WebView Engine Updates or OEM Swaps)
+    var isWebViewEngineUnavailable by remember { mutableStateOf(false) }
+
+    // Access Context via CompositionLocal
+    val context = LocalContext.current
+    val activityContext = context.findActivity()
 
     // WebView BackHandler
     BackHandler {
@@ -80,54 +103,74 @@ fun LifecycleAwareWebView(
         }
     }
 
-    AndroidView(
-        modifier = modifier,
-        factory = { context ->
-            WebView(context).apply {
-                // Application Default Configuration for Hosting WebApp
+    // If WebViewEngine is not available
+    if (isWebViewEngineUnavailable || activityContext == null) {
+        PlaceholderScreen(
+            modifier = modifier,
+            imageResource = R.drawable.question_mark,
+            contentText = stringResource(R.string.text_content_unavailable)
+        )
+    } else {
+        AndroidView(
+            modifier = modifier,
+            factory = { _ ->
+                // Instead of using context provided via factory lambda, use explicitly retrieved context
+                // to perform Early Exit to avoid unnecessary heavy composition task.
+                try {
+                    WebView(activityContext).apply {
+                        // Application Default Configuration for Hosting WebApp
 
-                // Let WebView uses all available spaces assigned.
-                layoutParams = ViewGroup.LayoutParams(
-                    ViewGroup.LayoutParams.MATCH_PARENT,
-                    ViewGroup.LayoutParams.MATCH_PARENT
-                )
+                        // Let WebView uses all available spaces assigned.
+                        layoutParams = ViewGroup.LayoutParams(
+                            ViewGroup.LayoutParams.MATCH_PARENT,
+                            ViewGroup.LayoutParams.MATCH_PARENT
+                        )
 
-                if (dynamicThemeEnabled) setBackgroundColor(Color.TRANSPARENT)
+                        if (dynamicThemeEnabled) setBackgroundColor(Color.TRANSPARENT)
 
-                // WebView Default Settings for seamless UX in Hybrid condition.
-                overScrollMode = View.OVER_SCROLL_NEVER
-                isVerticalScrollBarEnabled = false
-                isHorizontalScrollBarEnabled = false
+                        // WebView Default Settings for seamless UX in Hybrid condition.
+                        overScrollMode = View.OVER_SCROLL_NEVER
+                        isVerticalScrollBarEnabled = false
+                        isHorizontalScrollBarEnabled = false
 
-                // WebView Performance Settings
-                settings.apply {
-                    @SuppressLint("SetJavaScriptEnabled")
-                    javaScriptEnabled = true
-                    domStorageEnabled = true
-                    // Enable Global Cache Policy
-                    cacheMode = WebSettings.LOAD_DEFAULT
+                        // WebView Performance Settings
+                        settings.apply {
+                            @SuppressLint("SetJavaScriptEnabled")
+                            javaScriptEnabled = true
+                            domStorageEnabled = true
+                            // Enable Global Cache Policy
+                            cacheMode = WebSettings.LOAD_DEFAULT
 
-                    // Ensure responsiveness
-                    useWideViewPort = true          // support HTML viewport tag.
-                    loadWithOverviewMode = true     // Zoom out to fit entire content initially.
+                            // Ensure responsiveness
+                            useWideViewPort = true          // support HTML viewport tag.
+                            loadWithOverviewMode = true     // Zoom out to fit entire content initially.
+                        }
+
+                        // Prevent user long-click on WebView Content (by consuming it.)
+                        setOnLongClickListener { true }
+
+                        // Additional Configuration injected (Client, Listener)
+                        onWebViewCreate(this)
+
+                        // allocate the Instance
+                        webViewInstance = this
+                    }
+                } catch (e: Exception) {
+                    // Potential Exception Thrown: AndroidRuntimeException, ResourceNotFoundException
+                    isWebViewEngineUnavailable = true
+
+                    Log.e("LifecycleAwareWebView", "Exception: ${e.localizedMessage}")
+                    // Return fallback dummy screen
+                    View(activityContext)
                 }
-
-                // Prevent user long-click on WebView Content (by consuming it.)
-                setOnLongClickListener { true }
-
-                // Additional Configuration injected (Client, Listener)
-                onWebViewCreate(this)
-
-                // allocate the Instance
-                webViewInstance = this
+            },
+            update = { view ->
+                // Load WebApp
+                if (view is WebView && lastLoadedUrl != url) {
+                    view.loadUrl(url)
+                    lastLoadedUrl = url
+                }
             }
-        },
-        update = { view ->
-            // Load WebApp
-            if (lastLoadedUrl != url) {
-                view.loadUrl(url)
-                lastLoadedUrl = url
-            }
-        }
-    )
+        )
+    }
 }

--- a/feature/main/src/main/java/com/doyoonkim/main/campus/components/LifecycleAwareAndroidView.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/campus/components/LifecycleAwareAndroidView.kt
@@ -52,7 +52,7 @@ fun LifecycleAwareWebView(
 
     // Access Context via CompositionLocal
     val context = LocalContext.current
-    val activityContext = context.findActivity()
+    val activityContext = remember(context) { context.findActivity() }
 
     // WebView BackHandler
     BackHandler {
@@ -159,7 +159,7 @@ fun LifecycleAwareWebView(
                     // Potential Exception Thrown: AndroidRuntimeException, ResourceNotFoundException
                     isWebViewEngineUnavailable = true
 
-                    Log.e("LifecycleAwareWebView", "Exception: ${e.localizedMessage}")
+                    Log.e("LifecycleAwareWebView", "WebView Unavailable ${e.localizedMessage}")
                     // Return fallback dummy screen
                     View(activityContext)
                 }


### PR DESCRIPTION
## 📝 Summary (개요)
- Fatal issues reported from 1.7.1 release artifact have been resolved.
## 🔗 Related Issue (관련 이슈)
- Resolves _(if applicable)_ #
- Jira Ticket: [KAN-125]

## 🛠 Type of Change (변경 사항)
- [ ] `FEAT`: New feature (새로운 기능)
- [ ] `FIX`: Bug fix (버그 수정)
- [ ] `REFACTOR`: Code refactoring (no functional change) (코드 리팩토링)
- [ ] `DESIGN`: UI/UX changes (디자인 변경)
- [x] `!HOTFIX`: Critical fix (치명적인 버그 수정)
- [x] `CHORE`: Build/Config/CI (빌드/설정/CI)

## ✨ Key Changes (핵심 변경 사항)
- Resolve unexpected RuntimeException/ResourceNotFoundException occurred in `LifecycleAwareWebView` composable. (Due to both app-level and OS-level issue.)
  * Jetpack Compose can yield `ContextWrapper` instead of `Activity` due to its design pattern. If `ContextWrapper` is provided, WebView becomes unavailable and throws RuntimeException. 
  * WebView itself and Chrome could be unavailable due to OS-level reason. In this case, ResourceNotFoundException can be thrown.
- Implement exception handling logic in `TokenHandler` to gracefully handle a potential `IOException` cause by Firebase Service (Firebase Service is unavailable on User's device)

## 📸 Screenshots / Video (스크린샷 또는 동영상)
| Fallback Screen Sample |
|:---:|
| <img src="https://github.com/user-attachments/assets/9dc4bc4d-9924-4916-9121-b111cd3c2f58" width="300" /> |

## 🧪 Test Plan (테스트 계획)
- [x] **Device**: Android Emulator (Google Pixel 9 Pro; SDK 36)
- [x] **Scenario**: Manually inject `ApplicationContext` to `LifecycleAwareWebView` composable -> Check Fallback Screen is visible.
- [x] **Scenario**: Manually disable WebView `com.google.android.webview` and Chrome `com.android.chrome`. -> Check Fallback Screen is visible.

## ✅ Checklist (체크리스트)
- [x] My code follows the style guidelines of this project (코드 스타일을 준수했습니다).
- [x] I have performed a self-review of my own code (스스로 코드를 검토했습니다).
- [x] I have commented my code, particularly in hard-to-understand areas (이해하기 어려운 부분에 주석을 작성했습니다).


[KAN-125]: https://knutice.atlassian.net/browse/KAN-125?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ