### PR TITLE
[REFACTOR] Improve Local Major Subscription Management

### DIFF
--- a/app/src/main/java/com/doyoonkim/knutice/WidgetSyncObserver.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/WidgetSyncObserver.kt
@@ -12,6 +12,7 @@ import com.doyoonkim.widget.model.WidgetNoticeVO
 import com.doyoonkim.widget.model.WidgetState
 import com.doyoonkim.widget.util.WidgetStateUpdater
 import kotlinx.coroutines.CoroutineScope
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -58,10 +59,10 @@ class WidgetSyncObserver @Inject constructor(
                             )
                         }
                         is WidgetCategoryPolicy.Major -> {
-                            val majorCategory = appSubscriptionPreference.getSubscribedMajor()
-                            majorCategory?.let {
+                            val majorCategory = appSubscriptionPreference.getSubscribedMajor().first()
+                            if (majorCategory.isNotEmpty()) {
                                 updateNoticeWidgetState(
-                                    WidgetState(it, noticeCache)
+                                    WidgetState(majorCategory.first(), noticeCache)
                                 )
                             }
                         }

--- a/app/src/main/java/com/doyoonkim/knutice/di/components/AppComponent.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/di/components/AppComponent.kt
@@ -16,8 +16,10 @@ import com.doyoonkim.common.worker.IntermediateWorkerFactory
 import com.doyoonkim.data.di.CampusRemoteModule
 import com.doyoonkim.data.di.LocalPreferenceModule
 import com.doyoonkim.data.di.NoticeRemoteModule
+import com.doyoonkim.data.di.PreferencesRemoteModule
 import com.doyoonkim.data.di.RoomDatabaseModule
 import com.doyoonkim.data.di.SystemCoroutineModule
+import com.doyoonkim.domain.di.PreferencesUseCaseModule
 import com.doyoonkim.infrastructure.di.FirebaseAnalyticsModule
 import com.doyoonkim.infrastructure.di.FirebaseRemoteConfigModule
 import com.doyoonkim.knutice.di.util.FirebaseInfrastructureProvider
@@ -75,10 +77,12 @@ interface AppComponent :
     modules = [
         WorkerModule::class,
         WidgetModule::class,
+        PreferencesUseCaseModule::class,
         FcmTokenModule::class,
         TokenUseCaseModule::class,
         TokenRemoteModule::class,
         AsyncFtsEntryInsertionModule::class,
+        PreferencesRemoteModule::class,
         NoticeRemoteModule::class,
         CampusRemoteModule::class
     ]

--- a/app/src/main/java/com/doyoonkim/knutice/di/components/SceneComponents.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/di/components/SceneComponents.kt
@@ -76,9 +76,9 @@ interface HomeSceneComponent {
     ],
     modules = [
         ViewModelFactoryModule::class,
+        WorkSchedulerModule::class,
         NoticeByMajorSceneModule::class,
         NoticeUseCaseModule::class,
-        PreferencesUseCaseModule::class,
         NoticeRemoteModule::class,
         PreferencesRemoteModule::class
     ]

--- a/app/src/main/java/com/doyoonkim/knutice/di/modules/AppModule.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/di/modules/AppModule.kt
@@ -5,6 +5,11 @@ import android.app.Application
 import android.app.NotificationManager
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.SharedPreferencesMigration
+import androidx.datastore.preferences.core.PreferenceDataStoreFactory
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.preferencesDataStoreFile
 import androidx.work.WorkManager
 import com.doyoonkim.model.di.ApplicationContext
 import dagger.Module
@@ -41,5 +46,24 @@ object AppModule {
     @Singleton
     fun providesWorkManager(@ApplicationContext context: Context) =
         WorkManager.getInstance(context)
+
+    // PreferenceDataStore
+    @Provides
+    @Singleton
+    fun providePreferenceDataStore(@ApplicationContext context: Context): DataStore<Preferences> =
+        PreferenceDataStoreFactory.create(
+            // Partial Key migration: SUBSCRIBED MAJOR
+            migrations = listOf(
+                SharedPreferencesMigration(
+                    context = context,
+                    sharedPreferencesName = "app_pref",
+                    // Once full migration is required, remove this line to let Migration triggers ALL_KEYS_MIGRATION.
+                    keysToMigrate = setOf("SUBSCRIBED_MAJOR")
+                )
+            ),
+            produceFile = {
+                context.preferencesDataStoreFile(name = "user_preferences")
+            }
+        )
 
 }

--- a/app/src/main/java/com/doyoonkim/knutice/di/modules/WorkerModule.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/di/modules/WorkerModule.kt
@@ -7,6 +7,9 @@ import com.doyoonkim.knutice.task.AsyncFtsTaskSchedulerImpl
 import com.doyoonkim.common.worker.IntermediateWorkerFactory
 import com.doyoonkim.domain.interfaces.AsyncCarrelWidgetTaskScheduler
 import com.doyoonkim.domain.interfaces.AsyncNoticeWidgetTaskScheduler
+import com.doyoonkim.domain.interfaces.MajorSubscriptionUpdateTaskScheduler
+import com.doyoonkim.knutice.task.MajorSubscriptionUpdate
+import com.doyoonkim.knutice.task.MajorSubscriptionUpdateSchedulerImpl
 import com.doyoonkim.notification.task.PeriodicTokenRegistration
 import com.doyoonkim.widget.worker.AsyncNoticeWidgetTaskSchedulerImpl
 import com.doyoonkim.widget.worker.CarrelWidgetTaskSchedulerImpl
@@ -31,6 +34,13 @@ abstract class WorkerModule {
         factory: AsyncFtsTableInsertion.Factory
     ): IntermediateWorkerFactory
 
+    @Binds
+    @IntoMap
+    @WorkerKey(MajorSubscriptionUpdate::class)
+    abstract fun bindsMajorSubscriptionUpdateWorker(
+        factory: MajorSubscriptionUpdate.Factory
+    ): IntermediateWorkerFactory
+
 }
 
 @Module
@@ -49,4 +59,9 @@ abstract class WorkSchedulerModule {
     abstract fun bindCarrelWidgetWorkScheduler(
         impl: CarrelWidgetTaskSchedulerImpl
     ): AsyncCarrelWidgetTaskScheduler
+
+    @Binds
+    abstract fun bindMajorSubscriptionUpdateScheduler(
+        impl: MajorSubscriptionUpdateSchedulerImpl
+    ): MajorSubscriptionUpdateTaskScheduler
 }

--- a/app/src/main/java/com/doyoonkim/knutice/di/util/DefaultSystemService.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/di/util/DefaultSystemService.kt
@@ -4,6 +4,8 @@ import android.app.AlarmManager
 import android.app.NotificationManager
 import android.content.Context
 import android.content.SharedPreferences
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
 import androidx.work.WorkManager
 import com.doyoonkim.common.analytics.AnalyticsLogger
 import com.doyoonkim.domain.interfaces.AppDatabasePreferenceRepository
@@ -32,6 +34,8 @@ interface SystemServices {
     fun notificationManager(): NotificationManager
     // WorkManager
     fun workManager(): WorkManager
+    // PreferencesDataStore
+    fun preferenceDataStore(): DataStore<Preferences>
 
     // Dispatchers
     @IoDispatcher fun ioDispatcher(): CoroutineDispatcher

--- a/app/src/main/java/com/doyoonkim/knutice/task/MajorSubscriptionUpdate.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/task/MajorSubscriptionUpdate.kt
@@ -21,94 +21,67 @@ class MajorSubscriptionUpdate(
     private val appSubscriptionPreferenceRepository: AppSubscriptionPreferenceRepository
 ): CoroutineWorker(appContext, workerParam) {
     override suspend fun doWork(): Result {
-        // Perform Major Topic Subscription Update work.
-        // 1. Update necessary value.
-        // 2. Check prev registered topic.
-        // 3. Necessary deletion work.
-        val updateTarget = appSubscriptionPreferenceRepository.getSubscriptionPending().first()
-        val unsubscribeTargets = appSubscriptionPreferenceRepository.getUnsubscribePending().first()
-
-        /* TEMPORARY LOG FOR DEBUG */
-        Log.d("MajorSubscriptionUpdate", "SUBSCRIPTION PENDING: ${updateTarget.toList()}")
-        Log.d("MajorSubscriptionUpdate", "UNSUBSCRIPTION PENDING: ${unsubscribeTargets.toList()}")
-
-        if (updateTarget.isEmpty()) return Result.failure()
-
-        // New Major to subscribe
-        updateTarget.forEach { target ->
-            val result = submitNotificationPreferences.invoke(
-                TopicSubscriptionPreferencesBody(
-                    topicType = TopicType.MAJOR,
-                    noticeName = target,
-                    isSubscribed = true
-                )
-            ).first()
+        try {
+            // Perform Major Topic Subscription Update work.
+            // 1. Update necessary value.
+            // 2. Check prev registered topic.
+            // 3. Necessary deletion work.
+            val updateTarget = appSubscriptionPreferenceRepository.getSubscriptionPending().first()
+            val unsubscribeTargets = appSubscriptionPreferenceRepository.getUnsubscribePending().first()
 
             /* TEMPORARY LOG FOR DEBUG */
-            Log.d("MajorSubscriptionUpdate", "Subscribing target $target processed with result $result")
+            Log.d("MajorSubscriptionUpdate", "SUBSCRIPTION PENDING: ${updateTarget.toList()}")
+            Log.d("MajorSubscriptionUpdate", "UNSUBSCRIPTION PENDING: ${unsubscribeTargets.toList()}")
 
-            // Regardless of retryCount, registration must be completed, in order to
-            // promise PUSH notification on this topic.
-            if (!result) return Result.retry()
-        }
-        // Clear out pending list.
-        // Clear pending list early. In case, retry occurred in unsubscribed logic, above process will be safely ignored because
-        // updateTarget would be empty.
-        appSubscriptionPreferenceRepository.removePendingTarget(updateTarget)
+            // In case both pending lists are empty, early exit the work with Success result.
+            if (updateTarget.isEmpty() && unsubscribeTargets.isEmpty()) return Result.success()
 
-        unsubscribeTargets.forEach {
-            val unsubscribePrevTopic = submitNotificationPreferences.invoke(
-                TopicSubscriptionPreferencesBody(
-                    topicType = TopicType.MAJOR,
-                    noticeName = it,
-                    isSubscribed = false
-                )
-            ).first()
+            // New Major to subscribe
+            updateTarget.forEach { target ->
+                val result = submitNotificationPreferences.invoke(
+                    TopicSubscriptionPreferencesBody(
+                        topicType = TopicType.MAJOR,
+                        noticeName = target,
+                        isSubscribed = true
+                    )
+                ).first()
 
-            /* TEMPORARY LOG FOR DEBUG */
-            Log.d("MajorSubscriptionUpdate", "Subscribing target $it processed with result $unsubscribePrevTopic")
+                /* TEMPORARY LOG FOR DEBUG */
+                Log.d("MajorSubscriptionUpdate", "Subscribing target $target processed with result $result")
 
-            // Regardless of retryCount, unsubscription must be completed, in order to avoid
-            // PUSH notification on this topic.
-            if (!unsubscribePrevTopic) return Result.retry()
-        }
-
-        // All unsubscription is completed.
-        appSubscriptionPreferenceRepository.removeUnsubscribedTarget(unsubscribeTargets)
-        return Result.success()
-
-        /*    Old Logics.
-        // State Update & Request subscription update on Remote Source.
-        viewModelScope.launch {
-            val subscribeNewTopic = submitNotificationPreferences.invoke(
-                TopicSubscriptionPreferencesBody(
-                    topicType = TopicType.MAJOR,
-                    noticeName = newSubscription.name,
-                    isSubscribed = true
-                )
-            ).first()
-
-            if (subscribeNewTopic) {
-                val unsubscribePrevTopic = prevSubscription?.let { prev ->
-                    submitNotificationPreferences.invoke(
-                        TopicSubscriptionPreferencesBody(
-                            topicType = TopicType.MAJOR,
-                            noticeName = prev,
-                            isSubscribed = false
-                        )
-                    ).first()
-                } ?: true
-
-                if (unsubscribePrevTopic) {
-                    // update
-                    appSubscriptionPreference.updateSubscribedMajor(newSubscription.name)
-                    mutate(NoticeByMajorMutation.Subscribed(newSubscription))
-                    // Fetch new notices
-                    loadNotices()
-                }
+                // Regardless of retryCount, registration must be completed, in order to
+                // promise PUSH notification on this topic.
+                if (!result) return Result.retry()
             }
+            // Clear out pending list.
+            // Clear pending list early. In case, retry occurred in unsubscribed logic, above process will be safely ignored because
+            // updateTarget would be empty.
+            appSubscriptionPreferenceRepository.removePendingTarget(updateTarget)
+
+            unsubscribeTargets.forEach {
+                val unsubscribePrevTopic = submitNotificationPreferences.invoke(
+                    TopicSubscriptionPreferencesBody(
+                        topicType = TopicType.MAJOR,
+                        noticeName = it,
+                        isSubscribed = false
+                    )
+                ).first()
+
+                /* TEMPORARY LOG FOR DEBUG */
+                Log.d("MajorSubscriptionUpdate", "Subscribing target $it processed with result $unsubscribePrevTopic")
+
+                // Regardless of retryCount, unsubscription must be completed, in order to avoid
+                // PUSH notification on this topic.
+                if (!unsubscribePrevTopic) return Result.retry()
+            }
+
+            // All unsubscription is completed.
+            appSubscriptionPreferenceRepository.removeUnsubscribedTarget(unsubscribeTargets)
+            return Result.success()
+        } catch (e: Exception) {
+            Log.d("MajorSubscriptionUpdate", "Unable to process Server-side Synchronization\nReason:${e.stackTraceToString()}")
+            return Result.retry()
         }
-         */
     }
 
     class Factory @Inject constructor(

--- a/app/src/main/java/com/doyoonkim/knutice/task/MajorSubscriptionUpdate.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/task/MajorSubscriptionUpdate.kt
@@ -1,0 +1,129 @@
+package com.doyoonkim.knutice.task
+
+import android.content.Context
+import android.util.Log
+import androidx.work.CoroutineWorker
+import androidx.work.ListenableWorker
+import androidx.work.WorkerParameters
+import com.doyoonkim.common.worker.IntermediateWorkerFactory
+import com.doyoonkim.domain.interfaces.AppSubscriptionPreferenceRepository
+import com.doyoonkim.domain.usecases.SubmitNotificationPreferences
+import com.doyoonkim.model.TopicType
+import com.doyoonkim.model.di.ApplicationContext
+import com.doyoonkim.model.requestBody.TopicSubscriptionPreferencesBody
+import kotlinx.coroutines.flow.first
+import javax.inject.Inject
+
+class MajorSubscriptionUpdate(
+    appContext: Context,
+    workerParam: WorkerParameters,
+    private val submitNotificationPreferences: SubmitNotificationPreferences,
+    private val appSubscriptionPreferenceRepository: AppSubscriptionPreferenceRepository
+): CoroutineWorker(appContext, workerParam) {
+    override suspend fun doWork(): Result {
+        // Perform Major Topic Subscription Update work.
+        // 1. Update necessary value.
+        // 2. Check prev registered topic.
+        // 3. Necessary deletion work.
+        val updateTarget = appSubscriptionPreferenceRepository.getSubscriptionPending().first()
+        val unsubscribeTargets = appSubscriptionPreferenceRepository.getUnsubscribePending().first()
+
+        /* TEMPORARY LOG FOR DEBUG */
+        Log.d("MajorSubscriptionUpdate", "SUBSCRIPTION PENDING: ${updateTarget.toList()}")
+        Log.d("MajorSubscriptionUpdate", "UNSUBSCRIPTION PENDING: ${unsubscribeTargets.toList()}")
+
+        if (updateTarget.isEmpty()) return Result.failure()
+
+        // New Major to subscribe
+        updateTarget.forEach { target ->
+            val result = submitNotificationPreferences.invoke(
+                TopicSubscriptionPreferencesBody(
+                    topicType = TopicType.MAJOR,
+                    noticeName = target,
+                    isSubscribed = true
+                )
+            ).first()
+
+            /* TEMPORARY LOG FOR DEBUG */
+            Log.d("MajorSubscriptionUpdate", "Subscribing target $target processed with result $result")
+
+            // Regardless of retryCount, registration must be completed, in order to
+            // promise PUSH notification on this topic.
+            if (!result) return Result.retry()
+        }
+        // Clear out pending list.
+        // Clear pending list early. In case, retry occurred in unsubscribed logic, above process will be safely ignored because
+        // updateTarget would be empty.
+        appSubscriptionPreferenceRepository.removePendingTarget(updateTarget)
+
+        unsubscribeTargets.forEach {
+            val unsubscribePrevTopic = submitNotificationPreferences.invoke(
+                TopicSubscriptionPreferencesBody(
+                    topicType = TopicType.MAJOR,
+                    noticeName = it,
+                    isSubscribed = false
+                )
+            ).first()
+
+            /* TEMPORARY LOG FOR DEBUG */
+            Log.d("MajorSubscriptionUpdate", "Subscribing target $it processed with result $unsubscribePrevTopic")
+
+            // Regardless of retryCount, unsubscription must be completed, in order to avoid
+            // PUSH notification on this topic.
+            if (!unsubscribePrevTopic) return Result.retry()
+        }
+
+        // All unsubscription is completed.
+        appSubscriptionPreferenceRepository.removeUnsubscribedTarget(unsubscribeTargets)
+        return Result.success()
+
+        /*    Old Logics.
+        // State Update & Request subscription update on Remote Source.
+        viewModelScope.launch {
+            val subscribeNewTopic = submitNotificationPreferences.invoke(
+                TopicSubscriptionPreferencesBody(
+                    topicType = TopicType.MAJOR,
+                    noticeName = newSubscription.name,
+                    isSubscribed = true
+                )
+            ).first()
+
+            if (subscribeNewTopic) {
+                val unsubscribePrevTopic = prevSubscription?.let { prev ->
+                    submitNotificationPreferences.invoke(
+                        TopicSubscriptionPreferencesBody(
+                            topicType = TopicType.MAJOR,
+                            noticeName = prev,
+                            isSubscribed = false
+                        )
+                    ).first()
+                } ?: true
+
+                if (unsubscribePrevTopic) {
+                    // update
+                    appSubscriptionPreference.updateSubscribedMajor(newSubscription.name)
+                    mutate(NoticeByMajorMutation.Subscribed(newSubscription))
+                    // Fetch new notices
+                    loadNotices()
+                }
+            }
+        }
+         */
+    }
+
+    class Factory @Inject constructor(
+        @ApplicationContext private val appContext: Context,
+        private val submitNotificationPreferences: SubmitNotificationPreferences,
+        private val appSubscriptionPreferenceRepository: AppSubscriptionPreferenceRepository
+    ): IntermediateWorkerFactory {
+        override fun create(params: WorkerParameters): ListenableWorker {
+            return MajorSubscriptionUpdate(
+                appContext,
+                params,
+                submitNotificationPreferences,
+                appSubscriptionPreferenceRepository
+            )
+        }
+
+    }
+}

--- a/app/src/main/java/com/doyoonkim/knutice/task/MajorSubscriptionUpdateSchedulerImpl.kt
+++ b/app/src/main/java/com/doyoonkim/knutice/task/MajorSubscriptionUpdateSchedulerImpl.kt
@@ -1,0 +1,37 @@
+package com.doyoonkim.knutice.task
+
+import android.content.Context
+import androidx.work.BackoffPolicy
+import androidx.work.Constraints
+import androidx.work.ExistingWorkPolicy
+import androidx.work.NetworkType
+import androidx.work.OneTimeWorkRequestBuilder
+import androidx.work.WorkManager
+import com.doyoonkim.domain.interfaces.MajorSubscriptionUpdateTaskScheduler
+import com.doyoonkim.model.di.ApplicationContext
+import java.util.concurrent.TimeUnit
+import javax.inject.Inject
+
+class MajorSubscriptionUpdateSchedulerImpl @Inject constructor(
+    @ApplicationContext private val context: Context,
+    private val workManager: WorkManager
+): MajorSubscriptionUpdateTaskScheduler {
+    override fun execute() {
+        val onetimeWorkRequest = OneTimeWorkRequestBuilder<MajorSubscriptionUpdate>()
+            // let OS handles debounce.
+            .setInitialDelay(500, TimeUnit.MILLISECONDS)
+            .setBackoffCriteria(BackoffPolicy.EXPONENTIAL, 30, TimeUnit.SECONDS)
+            .setConstraints(
+                Constraints.Builder()
+                    .setRequiredNetworkType(NetworkType.CONNECTED)
+                    .build()
+            ).build()
+
+        workManager.enqueueUniqueWork(
+            "Updated Major Subscription Synchronization Work",
+            ExistingWorkPolicy.REPLACE,
+            onetimeWorkRequest
+        )
+    }
+
+}

--- a/core/data/build.gradle.kts
+++ b/core/data/build.gradle.kts
@@ -25,4 +25,7 @@ dependencies {
 
     // Kotlin Serialization
     implementation(libs.kotlin.serialization)
+
+    // PreferenceDataStore
+    implementation (libs.androidx.datastore.preferences)
 }

--- a/core/data/src/main/java/com/doyoonkim/data/repository/local/AppSubscriptionPreferenceRepositoryImpl.kt
+++ b/core/data/src/main/java/com/doyoonkim/data/repository/local/AppSubscriptionPreferenceRepositoryImpl.kt
@@ -1,30 +1,101 @@
 package com.doyoonkim.data.repository.local
 
-import android.content.SharedPreferences
-import androidx.core.content.edit
+import androidx.datastore.core.DataStore
+import androidx.datastore.preferences.core.Preferences
+import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringSetPreferencesKey
 import com.doyoonkim.domain.interfaces.AppSubscriptionPreferenceRepository
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.map
+
 import javax.inject.Inject
 
 class AppSubscriptionPreferenceRepositoryImpl @Inject constructor(
-    private val appPref: SharedPreferences
+    private val preferenceDataStore: DataStore<Preferences>
 ) : AppSubscriptionPreferenceRepository {
 
     companion object {
         private const val TAG = "AppSubscriptionPreferenceRepositoryImpl"
 
         // Major Subscription Status
+        @Deprecated("Use New PreferenceKey Value.")
         private const val SUBSCRIBED_MAJOR = "SUBSCRIBED_MAJOR"
+
+        // DataStore Preferences Key
+        private val MAJORS_SUBSCRIBED = stringSetPreferencesKey("MAJORS_SUBSCRIBED")
+        private val MAJORS_SUBSCRIPTION_PENDING = stringSetPreferencesKey("MAJORS_SUBSCRIPTION_PENDING")
+        private val MAJORS_TO_BE_UNSUBSCRIBED = stringSetPreferencesKey("MAJORS_UNSUBSCRIPTION_PENDING")
     }
+
 
     /**
      * Major Subscription Status
      */
-    override fun getSubscribedMajor(): String? {
-        return appPref.getString(SUBSCRIBED_MAJOR, null)
+    override fun getSubscribedMajor(): Flow<Set<String>> =
+        preferenceDataStore.data.map {
+            it[MAJORS_SUBSCRIBED] ?: emptySet()
+        }
+
+    override suspend fun updateSubscribedMajor(newMajor: String) {
+        preferenceDataStore.edit { preferences ->
+            // Subscription List for quick access on local.
+            /* Logic becomes enabled once business rule updated.
+                val currentTarget = preferences[MAJORS_SUBSCRIBED] ?: emptySet()
+                val updatedTarget = HashSet(currentTarget).apply { add(newMajor) }
+             */
+
+            // Update majors.
+            preferences[MAJORS_SUBSCRIBED] = setOf(newMajor)
+        }
     }
 
-    override fun updateSubscribedMajor(newMajor: String) {
-        appPref.edit { putString(SUBSCRIBED_MAJOR, newMajor) }
+    override fun getSubscriptionPending(): Flow<Set<String>> =
+        preferenceDataStore.data.map { it[MAJORS_SUBSCRIPTION_PENDING] ?: emptySet() }
+
+    override suspend fun addPendingTarget(target: String) {
+        preferenceDataStore.edit { preferences ->
+            // Pending Subscription Targets for server-side synchronization
+            val currentPending = preferences[MAJORS_SUBSCRIPTION_PENDING] ?: emptySet()
+            val newPending = HashSet(currentPending).apply { add(target) }
+
+            preferences[MAJORS_SUBSCRIPTION_PENDING] = newPending
+        }
+    }
+
+    override suspend fun removePendingTarget(completed: Set<String>) {
+        preferenceDataStore.edit { preferences ->
+            // Current Pending Status
+            val currentPending = preferences[MAJORS_SUBSCRIPTION_PENDING] ?: emptySet()
+            val updatedPending = HashSet(currentPending).apply { removeAll(completed) }
+
+            // Update pending majors to be subscribed
+            preferences[MAJORS_SUBSCRIPTION_PENDING] = updatedPending
+        }
+    }
+
+
+    // Temporarily store majors to be unsubscribed.
+    override fun getUnsubscribePending(): Flow<Set<String>> =
+        preferenceDataStore.data.map {
+            it[MAJORS_TO_BE_UNSUBSCRIBED] ?: emptySet()
+        }
+
+    override suspend fun removeUnsubscribedTarget(completed: Set<String>) {
+        preferenceDataStore.edit { preferences ->
+            val existingTargets = preferences[MAJORS_TO_BE_UNSUBSCRIBED] ?: emptySet()
+            val updatedTargets = HashSet(existingTargets).apply { removeAll(completed) }
+
+            preferences[MAJORS_TO_BE_UNSUBSCRIBED] = updatedTargets
+        }
+    }
+
+    override suspend fun updateUnsubscribeTarget(target: String) {
+        preferenceDataStore.edit { preferences ->
+            val existingTargets = preferences[MAJORS_TO_BE_UNSUBSCRIBED] ?: emptySet()
+            val updatedTargets = HashSet(existingTargets).apply { add(target) }
+
+            preferences[MAJORS_TO_BE_UNSUBSCRIBED] = updatedTargets
+        }
     }
 
 }

--- a/core/data/src/main/java/com/doyoonkim/data/repository/local/AppSubscriptionPreferenceRepositoryImpl.kt
+++ b/core/data/src/main/java/com/doyoonkim/data/repository/local/AppSubscriptionPreferenceRepositoryImpl.kt
@@ -3,6 +3,7 @@ package com.doyoonkim.data.repository.local
 import androidx.datastore.core.DataStore
 import androidx.datastore.preferences.core.Preferences
 import androidx.datastore.preferences.core.edit
+import androidx.datastore.preferences.core.stringPreferencesKey
 import androidx.datastore.preferences.core.stringSetPreferencesKey
 import com.doyoonkim.domain.interfaces.AppSubscriptionPreferenceRepository
 import kotlinx.coroutines.flow.Flow
@@ -32,8 +33,11 @@ class AppSubscriptionPreferenceRepositoryImpl @Inject constructor(
      * Major Subscription Status
      */
     override fun getSubscribedMajor(): Flow<Set<String>> =
-        preferenceDataStore.data.map {
-            it[MAJORS_SUBSCRIBED] ?: emptySet()
+        preferenceDataStore.data.map {preference ->
+            preference[MAJORS_SUBSCRIBED]
+                // Check if pre-existing subscription value in SharedPreference, apply it to updated subscription value.
+                ?: preference[stringPreferencesKey(SUBSCRIBED_MAJOR)]?.let { setOf(it) }
+                ?: emptySet()
         }
 
     override suspend fun updateSubscribedMajor(newMajor: String) {

--- a/core/domain/src/main/java/com/doyoonkim/domain/interfaces/AppSubscriptionPreferenceRepository.kt
+++ b/core/domain/src/main/java/com/doyoonkim/domain/interfaces/AppSubscriptionPreferenceRepository.kt
@@ -1,13 +1,27 @@
 package com.doyoonkim.domain.interfaces
 
+import kotlinx.coroutines.flow.Flow
+
 /**
  * @author kimdoyoon
  * Created 3/25/26 at 10:40 PM
  */
 interface AppSubscriptionPreferenceRepository {
 
-    fun getSubscribedMajor(): String?
+    fun getSubscribedMajor(): Flow<Set<String>>
 
-    fun updateSubscribedMajor(newMajor: String)
+    suspend fun updateSubscribedMajor(newMajor: String)
+
+    fun getSubscriptionPending(): Flow<Set<String>>
+
+    suspend fun addPendingTarget(target: String)
+    suspend fun removePendingTarget(completed: Set<String>)
+
+    fun getUnsubscribePending(): Flow<Set<String>>
+
+    suspend fun removeUnsubscribedTarget(completed: Set<String>)
+
+    suspend fun updateUnsubscribeTarget(target: String)
+
 
 }

--- a/core/domain/src/main/java/com/doyoonkim/domain/interfaces/MajorSubscriptionUpdateTaskScheduler.kt
+++ b/core/domain/src/main/java/com/doyoonkim/domain/interfaces/MajorSubscriptionUpdateTaskScheduler.kt
@@ -1,0 +1,5 @@
+package com.doyoonkim.domain.interfaces
+
+interface MajorSubscriptionUpdateTaskScheduler {
+    fun execute()
+}

--- a/feature/main/src/main/java/com/doyoonkim/main/viewmodel/HomeViewModel.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/viewmodel/HomeViewModel.kt
@@ -23,6 +23,7 @@ import com.doyoonkim.model.NoticeCategory
 import com.doyoonkim.model.WidgetCategoryPolicy
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.distinctUntilChanged
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.flow.map
 import kotlinx.coroutines.launch
 import javax.inject.Inject
@@ -152,24 +153,24 @@ class HomeViewModel @Inject constructor(
 
     // Side Effect (Access SharedPreference)
     private fun getMajorSubscriptionStatus() = viewModelScope.launch {
-        val subscribed = appSubscriptionPreference.getSubscribedMajor()?.let {
-            MajorCategory.valueOf(it)
-        }
-        Log.d(this.javaClass.name, "Subscription: $subscribed")
-
-        subscribed?.let {
-            fetchTopThreeNotices.getMajorNotices(subscribed)
+        val subscribed = appSubscriptionPreference.getSubscribedMajor().first()
+        if (subscribed.isEmpty()) {
+            mutate(HomeMutation.MajorNotices.Failure("Unable to find subscribed major"))
+        } else {
+            Log.d(this.javaClass.name, "Subscription: $subscribed")
+            val selected = MajorCategory.valueOf(subscribed.first())
+            fetchTopThreeNotices.getMajorNotices(selected)
                 .fold(
-                    onSuccess = { result ->
-                        Log.d(this.javaClass.name, "Result: ${result.toString()}")
-                        mutate(HomeMutation.MajorNotices.Success(subscribed, result))
+                    onSuccess = {result ->
+                        Log.d(this.javaClass.name, "Result: $result")
+                        mutate(HomeMutation.MajorNotices.Success(selected, result))
                     },
-                    onFailure = { error ->
+                    onFailure = {error ->
                         Log.d(this.javaClass.name, "Result: ${error.stackTraceToString()}")
                         mutate(HomeMutation.MajorNotices.Failure(error.stackTraceToString()))
                     }
                 )
-        } ?: mutate(HomeMutation.MajorNotices.Failure("Unable to find subscribed major"))
+        }
     }
 
     private fun updateNoticeLocalCache(snapshot: HomeViewState) =

--- a/feature/main/src/main/java/com/doyoonkim/main/viewmodel/NoticeByMajorViewModel.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/viewmodel/NoticeByMajorViewModel.kt
@@ -4,15 +4,13 @@ import android.util.Log
 import androidx.lifecycle.viewModelScope
 import com.doyoonkim.common.base.BaseViewModel
 import com.doyoonkim.domain.interfaces.AppSubscriptionPreferenceRepository
+import com.doyoonkim.domain.interfaces.MajorSubscriptionUpdateTaskScheduler
 import com.doyoonkim.domain.usecases.FetchNoticesPerPage
-import com.doyoonkim.domain.usecases.SubmitNotificationPreferences
 import com.doyoonkim.main.contract.NoticeByMajorEvent
 import com.doyoonkim.main.contract.NoticeByMajorMutation
 import com.doyoonkim.main.contract.NoticeByMajorSideEffect
 import com.doyoonkim.main.contract.NoticeByMajorState
 import com.doyoonkim.model.MajorCategory
-import com.doyoonkim.model.TopicType
-import com.doyoonkim.model.requestBody.TopicSubscriptionPreferencesBody
 import kotlinx.coroutines.flow.collectLatest
 import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
@@ -21,7 +19,7 @@ import javax.inject.Inject
 class NoticeByMajorViewModel @Inject constructor(
     private val appSubscriptionPreference: AppSubscriptionPreferenceRepository,
     private val fetchNoticesPerPage: FetchNoticesPerPage,
-    private val submitNotificationPreferences: SubmitNotificationPreferences
+    private val jobScheduler: MajorSubscriptionUpdateTaskScheduler
 ): BaseViewModel<NoticeByMajorState, NoticeByMajorEvent, NoticeByMajorSideEffect, NoticeByMajorMutation>() {
     private val TAG = this.javaClass.name
     override fun setInitialState(): NoticeByMajorState = NoticeByMajorState(0)
@@ -64,49 +62,33 @@ class NoticeByMajorViewModel @Inject constructor(
     }
 
     private fun initialLoad() {
-        val currentSubscription = appSubscriptionPreference.getSubscribedMajor()
-        currentSubscription?.let { subscribed ->
-            mutate(NoticeByMajorMutation.Subscribed(MajorCategory.valueOf(subscribed)))
-        }
         viewModelScope.launch {
+            val currentSubscription = appSubscriptionPreference.getSubscribedMajor().first()
+            // Temporary
+            if (currentSubscription.isNotEmpty()) {
+                mutate(NoticeByMajorMutation.Subscribed(MajorCategory.valueOf(currentSubscription.first())))
+            }
             fetchNotice()
         }
     }
 
     // Need to revised later.
     private fun updateSubscribedMajor(newSubscription: MajorCategory) {
-        mutate(NoticeByMajorMutation.Notices.Loading)
-
-        val prevSubscription = appSubscriptionPreference.getSubscribedMajor()
-        // State Update & Request subscription update on Remote Source.
         viewModelScope.launch {
-            val subscribeNewTopic = submitNotificationPreferences.invoke(
-                TopicSubscriptionPreferencesBody(
-                    topicType = TopicType.MAJOR,
-                    noticeName = newSubscription.name,
-                    isSubscribed = true
-                )
-            ).first()
+            // Temporary Overall processing
+            val prevSubscription = appSubscriptionPreference.getSubscribedMajor().first()
+            // Add prevSubscription Major to unsubscribe targets
+            if (prevSubscription.isNotEmpty()) appSubscriptionPreference.updateUnsubscribeTarget(prevSubscription.first())
+            // Register new topic
+            appSubscriptionPreference.updateSubscribedMajor(newSubscription.name)
+            // Add new topic to Subscription Pending
+            appSubscriptionPreference.addPendingTarget(newSubscription.name)
+            // Trigger background work for server-side synchronization
+            jobScheduler.execute()
 
-            if (subscribeNewTopic) {
-                val unsubscribePrevTopic = prevSubscription?.let { prev ->
-                    submitNotificationPreferences.invoke(
-                        TopicSubscriptionPreferencesBody(
-                            topicType = TopicType.MAJOR,
-                            noticeName = prev,
-                            isSubscribed = false
-                        )
-                    ).first()
-                } ?: true
-
-                if (unsubscribePrevTopic) {
-                    // update
-                    appSubscriptionPreference.updateSubscribedMajor(newSubscription.name)
-                    mutate(NoticeByMajorMutation.Subscribed(newSubscription))
-                    // Fetch new notices
-                    loadNotices()
-                }
-            }
+            // Trigger New Notices fetch
+            mutate(NoticeByMajorMutation.Subscribed(newSubscription))
+            loadNotices()
         }
     }
 

--- a/feature/main/src/main/java/com/doyoonkim/main/viewmodel/NotificationPreferencesViewModel.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/viewmodel/NotificationPreferencesViewModel.kt
@@ -21,6 +21,7 @@ import com.doyoonkim.model.NoticeCategory
 import com.doyoonkim.model.TopicType
 import com.doyoonkim.model.requestBody.TopicSubscriptionPreferencesBody
 import kotlinx.coroutines.flow.collectLatest
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -103,21 +104,23 @@ class NotificationPreferencesViewModel @Inject constructor(
     }
 
     private fun updateMajorSubscriptionStatus(state: Boolean) {
-        val subscribedMajor = appSubscriptionPreference.getSubscribedMajor() ?: return
         mutate(NotificationPrefMutation.Syncing)
-
+        // Temporary
         viewModelScope.launch {
-            submitNotificationPreferences.invoke(
-                TopicSubscriptionPreferencesBody(
-                    topicType = TopicType.MAJOR,
-                    noticeName = subscribedMajor,
-                    isSubscribed = state
-                )
-            ).collectLatest { result ->
-                if (result) {
-                    mutate(NotificationPrefMutation.Major.UpdateSuccess(state))
-                } else {
-                    mutate(NotificationPrefMutation.Major.Failure("Submit Failed"))
+            val subscribedMajor = appSubscriptionPreference.getSubscribedMajor().first()
+            if (subscribedMajor.isNotEmpty()) {
+                submitNotificationPreferences.invoke(
+                    TopicSubscriptionPreferencesBody(
+                        topicType = TopicType.MAJOR,
+                        noticeName = subscribedMajor.first(),
+                        isSubscribed = state
+                    )
+                ).collectLatest { result ->
+                    if (result) {
+                        mutate(NotificationPrefMutation.Major.UpdateSuccess(state))
+                    } else {
+                        mutate(NotificationPrefMutation.Major.Failure("Submit Failed"))
+                    }
                 }
             }
         }.invokeOnCompletion { mutate(NotificationPrefMutation.Synced) }
@@ -166,11 +169,11 @@ class NotificationPreferencesViewModel @Inject constructor(
                 .collectLatest { result ->
                     result.fold(
                         onSuccess = { status ->
-                            val cachedMajorSelection = appSubscriptionPreference.getSubscribedMajor()
-                            if (cachedMajorSelection != null) {
+                            val cachedMajorSelection = appSubscriptionPreference.getSubscribedMajor().first()
+                            if (cachedMajorSelection.isNotEmpty()) {
                                 var majorStatus = false
                                 if (status.isNotEmpty()) {
-                                    if (cachedMajorSelection != status.first().first) {
+                                    if (cachedMajorSelection.first() != status.first().first) {
                                         appSubscriptionPreference.updateSubscribedMajor(status.first().first)
                                     }
                                     majorStatus = status.first().second

--- a/feature/main/src/main/java/com/doyoonkim/main/viewmodel/WidgetConfigViewModel.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/viewmodel/WidgetConfigViewModel.kt
@@ -13,6 +13,7 @@ import com.doyoonkim.main.contract.WidgetConfigState
 import com.doyoonkim.model.NoticeCategory
 import com.doyoonkim.model.di.IoDispatcher
 import kotlinx.coroutines.CoroutineDispatcher
+import kotlinx.coroutines.flow.first
 import kotlinx.coroutines.launch
 import javax.inject.Inject
 
@@ -48,8 +49,13 @@ class WidgetConfigViewModel @Inject constructor(
         viewModelScope.launch(ioDispatcher) {
             // Default options (Main Notice Categories)
             val default: List<String> = NoticeCategory.entries.dropLast(1).map { it.name }
+            val majorSelection = appSubscriptionPreference.getSubscribedMajor().first().run {
+                if (isEmpty()) null
+                else first()
+            }
+
             mutate(WidgetConfigMutation.Configuration.Available(
-                default, appSubscriptionPreference.getSubscribedMajor()
+                default, majorSelection
             ))
             // Check Current Policy Status
             val currentPolicy = appWidgetPreference.getWidgetCategoryPolicy()

--- a/feature/widget/src/main/java/com/doyoonkim/widget/worker/KnuticeWidgetSync.kt
+++ b/feature/widget/src/main/java/com/doyoonkim/widget/worker/KnuticeWidgetSync.kt
@@ -15,6 +15,7 @@ import com.doyoonkim.model.WidgetCategoryPolicy
 import com.doyoonkim.widget.model.WidgetNoticeVO
 import com.doyoonkim.widget.model.WidgetState
 import com.doyoonkim.widget.util.WidgetStateUpdater
+import kotlinx.coroutines.flow.first
 import javax.inject.Inject
 
 class KnuticeWidgetSync(
@@ -78,9 +79,14 @@ class KnuticeWidgetSync(
             }
             is WidgetCategoryPolicy.Major -> {
                 // Get current subscription status.
-                val subscribedMajor = appSubscriptionPreference.getSubscribedMajor() ?: return null
-                category = subscribedMajor
-                return remoteRepository.queryTopThreeNotices(subscribedMajor)
+                val subscribedMajor = appSubscriptionPreference.getSubscribedMajor().first()
+
+                return if (subscribedMajor.isNotEmpty()) {
+                    category = subscribedMajor.first()
+                    remoteRepository.queryTopThreeNotices(category)
+                } else {
+                    null
+                }
             }
             else -> { return null }
         }


### PR DESCRIPTION
## 📝 Summary (개요)
- Improve local major subscription management to resolve identified issue caused by fragmented data source.
## 🔗 Related Issue (관련 이슈)
- Resolves _(if applicable)_ #
- Jira Ticket: [KAN-111]

## 🛠 Type of Change (변경 사항)
- [ ] `FEAT`: New feature (새로운 기능)
- [ ] `FIX`: Bug fix (버그 수정)
- [x] `REFACTOR`: Code refactoring (no functional change) (코드 리팩토링)
- [ ] `DESIGN`: UI/UX changes (디자인 변경)
- [ ] `!HOTFIX`: Critical fix (치명적인 버그 수정)
- [x] `CHORE`: Build/Config/CI (빌드/설정/CI)

## ✨ Key Changes (핵심 변경 사항)
- Local Major Subscription management has been migrated from `SharedPreference` to `PreferenceDataStore`.
  * Modifications have been made on necessary consumers to safely take value over `Flow<T>` and process it.
- Server-side synchronization process has been isolated and would be performed in background to ensure server-side synchronization to be completed although user leave the specific screen or close/kill the application process.
- Improved `AppSubscriptionPreferenceRepository` is architected with consideration of future scalability.

## 📸 Screenshots / Video (스크린샷 또는 동영상)
- Not Applicable.

## 🧪 Test Plan (테스트 계획)
- [x] **Device**: Android Emulator (Google Pixel 9 Pro, SDK 36)
- [x] **Scenario**: Launch application -> navigate to `NoticeByMajorScreen` -> Select Major -> Check selected major is applied -> Check server-side synchronization is performed.
- [x] **Scenario**: Change Major -> Check selected major is applied -> Check server-side synchronization is performed.

## ✅ Checklist (체크리스트)
- [x] My code follows the style guidelines of this project (코드 스타일을 준수했습니다).
- [x] I have performed a self-review of my own code (스스로 코드를 검토했습니다).
- [x] I have commented my code, particularly in hard-to-understand areas (이해하기 어려운 부분에 주석을 작성했습니다).


[KAN-111]: https://knutice.atlassian.net/browse/KAN-111?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ