### PR TITLE
[KAN-131] Add Optional TopNavBar on Custom WebView fallback.

### DIFF
--- a/feature/main/src/main/java/com/doyoonkim/main/campus/carrel/CarrelStatusScreen.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/campus/carrel/CarrelStatusScreen.kt
@@ -15,11 +15,15 @@ import androidx.compose.runtime.getValue
 import androidx.compose.runtime.mutableStateOf
 import androidx.compose.runtime.remember
 import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
 import androidx.lifecycle.compose.collectAsStateWithLifecycle
 import androidx.webkit.WebViewCompat
+import com.doyoonkim.common.R
 import com.doyoonkim.common.theme.displayBackground
+import com.doyoonkim.common.ui.NavButtonType
 import com.doyoonkim.main.BuildConfig
 import com.doyoonkim.main.campus.components.LifecycleAwareWebView
+import com.doyoonkim.main.campus.components.LifecycleAwareWebViewFallbackType
 import com.doyoonkim.main.campus.model.WebAppAction
 import com.doyoonkim.main.campus.model.WebBridgeEnvelop
 import com.doyoonkim.main.viewmodel.CarrelStatusViewModel
@@ -97,6 +101,7 @@ fun CarrelStatusScreen(
             .windowInsetsPadding(WindowInsets.systemBars)
             .background(MaterialTheme.colorScheme.displayBackground),
         url = BuildConfig.KNUTICE_ORIGIN + BuildConfig.CARREL_PATH,
+        fallbackType = LifecycleAwareWebViewFallbackType.Scaffold(stringResource(R.string.knutice_carrel_widget_title), NavButtonType.BACK),
         onWebViewCreate = { webView ->
             webView.webViewClient = webViewClient
 

--- a/feature/main/src/main/java/com/doyoonkim/main/campus/components/LifecycleAwareAndroidView.kt
+++ b/feature/main/src/main/java/com/doyoonkim/main/campus/components/LifecycleAwareAndroidView.kt
@@ -11,6 +11,11 @@ import android.view.ViewGroup
 import android.webkit.WebSettings
 import android.webkit.WebView
 import androidx.activity.compose.BackHandler
+import androidx.compose.foundation.layout.calculateEndPadding
+import androidx.compose.foundation.layout.calculateStartPadding
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.padding
+import androidx.compose.material3.Scaffold
 import androidx.compose.runtime.Composable
 import androidx.compose.runtime.DisposableEffect
 import androidx.compose.runtime.getValue
@@ -20,12 +25,15 @@ import androidx.compose.runtime.setValue
 import androidx.compose.ui.Modifier
 import androidx.compose.ui.platform.LocalContext
 import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.unit.LayoutDirection
 import androidx.compose.ui.viewinterop.AndroidView
 import androidx.lifecycle.Lifecycle
 import androidx.lifecycle.LifecycleEventObserver
 import androidx.lifecycle.compose.LocalLifecycleOwner
 import com.doyoonkim.common.R
+import com.doyoonkim.common.ui.NavButtonType
 import com.doyoonkim.common.ui.PlaceholderScreen
+import com.doyoonkim.common.ui.TopAppBarWithNavButton
 
 // App-Level Issue
 // Context Helper. Mitigate potential issue caused by Injected Context via Dagger.
@@ -35,11 +43,17 @@ private fun Context.findActivity(): Activity? = when (this) {
     else -> null
 }
 
+sealed interface LifecycleAwareWebViewFallbackType {
+    data object Simple : LifecycleAwareWebViewFallbackType
+    data class Scaffold(val title: String, val navButtonType: NavButtonType) : LifecycleAwareWebViewFallbackType
+}
+
 @Composable
 fun LifecycleAwareWebView(
     modifier: Modifier = Modifier,
     dynamicThemeEnabled: Boolean = true,
     url: String,
+    fallbackType: LifecycleAwareWebViewFallbackType = LifecycleAwareWebViewFallbackType.Simple,
     onWebViewCreate: (WebView) -> Unit = { },
     onWebViewDestroy: (WebView) -> Unit = { },
     onLeaveWebView: () -> Unit
@@ -109,11 +123,37 @@ fun LifecycleAwareWebView(
 
     // If WebViewEngine is not available
     if (isWebViewEngineUnavailable || activityContext == null) {
-        PlaceholderScreen(
-            modifier = modifier,
-            imageResource = R.drawable.question_mark,
-            contentText = stringResource(R.string.text_content_unavailable)
-        )
+        // KAN-131 Add TopNavBar to Fallback Placeholder screen on LifecycleAwareWebView.
+        when (fallbackType) {
+            is LifecycleAwareWebViewFallbackType.Scaffold -> {
+                Scaffold(
+                    topBar = {
+                        TopAppBarWithNavButton(
+                            modifier = Modifier.fillMaxWidth(),
+                            titleText = fallbackType.title,
+                            navButtonType = fallbackType.navButtonType,
+                            onBackPressed = onLeaveWebView
+                        )
+                    }
+                ) { contentPadding ->
+                    PlaceholderScreen(
+                        modifier = modifier.padding(
+                            start = contentPadding.calculateStartPadding(LayoutDirection.Ltr),
+                            end = contentPadding.calculateEndPadding(LayoutDirection.Ltr)
+                        ),
+                        imageResource = R.drawable.question_mark,
+                        contentText = stringResource(R.string.text_content_unavailable)
+                    )
+                }
+            }
+            is LifecycleAwareWebViewFallbackType.Simple -> {
+                PlaceholderScreen(
+                    modifier = modifier,
+                    imageResource = R.drawable.question_mark,
+                    contentText = stringResource(R.string.text_content_unavailable)
+                )
+            }
+        }
     } else {
         AndroidView(
             modifier = modifier,


### PR DESCRIPTION
## 📝 Summary (개요)
- Add Optional `TopNavBar` on Custom WebView (`LifecycleAwareWebView`) Fallback
## 🔗 Related Issue (관련 이슈)
- Resolves _(if applicable)_ #
- Jira Ticket: [KAN-131]

## 🛠 Type of Change (변경 사항)
- [ ] `FEAT`: New feature (새로운 기능)
- [ ] `FIX`: Bug fix (버그 수정)
- [x] `REFACTOR`: Code refactoring (no functional change) (코드 리팩토링)
- [x] `DESIGN`: UI/UX changes (디자인 변경)
- [ ] `!HOTFIX`: Critical fix (치명적인 버그 수정)
- [ ] `CHORE`: Build/Config/CI (빌드/설정/CI)

## ✨ Key Changes (핵심 변경 사항)
- Add new `sealed interface` to render Fallback Screen (`PlaceholderScreen`) dynamically, in deterministic way.
- If `LifecycleAwareWebView` renders a WebApp that includes Top Navigation Bar, a Fallback screen would be rendered alongside with its own `Scaffold` to provide better UX on loading error state.

## 📸 Screenshots / Video (스크린샷 또는 동영상)
| Before (이전) | After (이후) |
|:---:|:---:|
| <video src="https://github.com/user-attachments/assets/7bdd4273-6525-4fd8-be2b-90a126d3faef" width="270" /> | <video src="https://github.com/user-attachments/assets/095f4784-6d60-4793-88fd-5c7fccb11155" width="270" /> |

## 🧪 Test Plan (테스트 계획)
- [x] **Device**: Android Emulator (Pixel 10 Pro, SDK 36)
- [x] **Scenario**: Temporarily delete local properties for URL path -> launch Application -> Enter WebViewService -> Verify native TopNavBar is rendered.

## ✅ Checklist (체크리스트)
- [x] My code follows the style guidelines of this project (코드 스타일을 준수했습니다).
- [x] I have performed a self-review of my own code (스스로 코드를 검토했습니다).
- [x] I have commented my code, particularly in hard-to-understand areas (이해하기 어려운 부분에 주석을 작성했습니다).


[KAN-130]: https://knutice.atlassian.net/browse/KAN-130?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **개선 사항**
  * 웹 콘텐츠를 불러올 수 없는 상황에서도 화면 유형에 맞는 안내 화면을 표시합니다.
  * 열람실 현황 화면의 대체 화면에 제목과 뒤로가기 버튼이 제공됩니다.
  * 웹 화면 이용 중 환경 문제 발생 시에도 일관된 화면 구조와 탐색 경험을 제공합니다.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->

[KAN-131]: https://knutice.atlassian.net/browse/KAN-131?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ